### PR TITLE
Add setting to allow to bind http/https servers to specific ip

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -187,6 +187,7 @@ typedef struct
 
     bool flex_enabled;
     char *flex_uid;
+    char *bind_ip;
 } settings_core_t;
 
 typedef struct

--- a/src/server.c
+++ b/src/server.c
@@ -453,9 +453,19 @@ void server_init()
     HttpServerSettings https_settings;
     HttpServerContext http_context;
     HttpServerContext https_context;
+    IpAddr listenIpAddr;
 
     /* setup settings for HTTP */
     httpServerGetDefaultSettings(&http_settings);
+
+    const char * bindIp = settings_get_string("core.server.bind_ip");
+
+    if (bindIp != NULL && strlen(bindIp) > 0)
+    {
+        TRACE_INFO("Binding to ip %s only\r\n", bindIp);
+        ipStringToAddr(bindIp, &listenIpAddr);
+        http_settings.ipAddr = listenIpAddr;
+    }
 
     http_settings.maxConnections = APP_HTTP_MAX_CONNECTIONS;
     http_settings.connections = httpConnections;

--- a/src/server_helpers.c
+++ b/src/server_helpers.c
@@ -507,3 +507,279 @@ error_t multipart_handle(HttpConnection *connection, multipart_cbr_t *cbr, void 
 
     return NO_ERROR;
 }
+
+/**
+ * @brief Convert a dot-decimal string to a binary IPv4 address
+ * @param[in] str NULL-terminated string representing the IPv4 address
+ * @param[out] ipAddr Binary representation of the IPv4 address
+ * @return Error code
+ **/
+
+error_t ipv4StringToAddr(const char_t *str, Ipv4Addr *ipAddr)
+{
+   error_t error;
+   int_t i = 0;
+   int_t value = -1;
+
+   //Parse input string
+   while(1)
+   {
+      //Decimal digit found?
+      if(osIsdigit(*str))
+      {
+         //First digit to be decoded?
+         if(value < 0)
+            value = 0;
+
+         //Update the value of the current byte
+         value = (value * 10) + (*str - '0');
+
+         //The resulting value shall be in range 0 to 255
+         if(value > 255)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+            break;
+         }
+      }
+      //Dot separator found?
+      else if(*str == '.' && i < 4)
+      {
+         //Each dot must be preceded by a valid number
+         if(value < 0)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+            break;
+         }
+
+         //Save the current byte
+         ((uint8_t *) ipAddr)[i++] = value;
+         //Prepare to decode the next byte
+         value = -1;
+      }
+      //End of string detected?
+      else if(*str == '\0' && i == 3)
+      {
+         //The NULL character must be preceded by a valid number
+         if(value < 0)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+         }
+         else
+         {
+            //Save the last byte of the IPv4 address
+            ((uint8_t *) ipAddr)[i] = value;
+            //The conversion succeeded
+            error = NO_ERROR;
+         }
+
+         //We are done
+         break;
+      }
+      //Invalid character...
+      else
+      {
+         //The conversion failed
+         error = ERROR_INVALID_SYNTAX;
+         break;
+      }
+
+      //Point to the next character
+      str++;
+   }
+
+   //Return status code
+   return error;
+}
+
+/**
+ * @brief Convert a string representation of an IPv6 address to a binary IPv6 address
+ * @param[in] str NULL-terminated string representing the IPv6 address
+ * @param[out] ipAddr Binary representation of the IPv6 address
+ * @return Error code
+ **/
+
+error_t ipv6StringToAddr(const char_t *str, Ipv6Addr *ipAddr)
+{
+   error_t error;
+   int_t i = 0;
+   int_t j = -1;
+   int_t k = 0;
+   int32_t value = -1;
+
+   //Parse input string
+   while(1)
+   {
+      //Hexadecimal digit found?
+      if(isxdigit((uint8_t) *str))
+      {
+         //First digit to be decoded?
+         if(value < 0)
+            value = 0;
+
+         //Update the value of the current 16-bit word
+         if(osIsdigit(*str))
+         {
+            value = (value * 16) + (*str - '0');
+         }
+         else if(osIsupper(*str))
+         {
+            value = (value * 16) + (*str - 'A' + 10);
+         }
+         else
+         {
+            value = (value * 16) + (*str - 'a' + 10);
+         }
+
+         //Check resulting value
+         if(value > 0xFFFF)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+            break;
+         }
+      }
+      //"::" symbol found?
+      else if(!osStrncmp(str, "::", 2))
+      {
+         //The "::" can only appear once in an IPv6 address
+         if(j >= 0)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+            break;
+         }
+
+         //The "::" symbol is preceded by a number?
+         if(value >= 0)
+         {
+            //Save the current 16-bit word
+            ipAddr->w[i++] = htons(value);
+            //Prepare to decode the next 16-bit word
+            value = -1;
+         }
+
+         //Save the position of the "::" symbol
+         j = i;
+         //Point to the next character
+         str++;
+      }
+      //":" symbol found?
+      else if(*str == ':' && i < 8)
+      {
+         //Each ":" must be preceded by a valid number
+         if(value < 0)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+            break;
+         }
+
+         //Save the current 16-bit word
+         ipAddr->w[i++] = htons(value);
+         //Prepare to decode the next 16-bit word
+         value = -1;
+      }
+      //End of string detected?
+      else if(*str == '\0' && i == 7 && j < 0)
+      {
+         //The NULL character must be preceded by a valid number
+         if(value < 0)
+         {
+            //The conversion failed
+            error = ERROR_INVALID_SYNTAX;
+         }
+         else
+         {
+            //Save the last 16-bit word of the IPv6 address
+            ipAddr->w[i] = htons(value);
+            //The conversion succeeded
+            error = NO_ERROR;
+         }
+
+         //We are done
+         break;
+      }
+      else if(*str == '\0' && i < 7 && j >= 0)
+      {
+         //Save the last 16-bit word of the IPv6 address
+         if(value >= 0)
+            ipAddr->w[i++] = htons(value);
+
+         //Move the part of the address that follows the "::" symbol
+         for(k = 0; k < (i - j); k++)
+         {
+            ipAddr->w[7 - k] = ipAddr->w[i - 1 - k];
+         }
+
+         //A sequence of zeroes can now be written in place of "::"
+         for(k = 0; k < (8 - i); k++)
+         {
+            ipAddr->w[j + k] = 0;
+         }
+
+         //The conversion succeeded
+         error = NO_ERROR;
+         break;
+      }
+      //Invalid character...
+      else
+      {
+         //The conversion failed
+         error = ERROR_INVALID_SYNTAX;
+         break;
+      }
+
+      //Point to the next character
+      str++;
+   }
+
+   //Return status code
+   return error;
+}
+
+/**
+ * @brief Convert a string representation of an IP address to a binary IP address
+ * @param[in] str NULL-terminated string representing the IP address
+ * @param[out] ipAddr Binary representation of the IP address
+ * @return Error code
+ **/
+
+error_t ipStringToAddr(const char_t *str, IpAddr *ipAddr)
+{
+   error_t error;
+
+#if (IPV6_SUPPORT == ENABLED)
+   //IPv6 address?
+   if(osStrchr(str, ':') != NULL)
+   {
+      //IPv6 addresses are 16-byte long
+      ipAddr->length = sizeof(Ipv6Addr);
+      //Convert the string to IPv6 address
+      error = ipv6StringToAddr(str, &ipAddr->ipv6Addr);
+   }
+   else
+#endif
+#if (IPV4_SUPPORT == ENABLED)
+   //IPv4 address?
+   if(osStrchr(str, '.') != NULL)
+   {
+      //IPv4 addresses are 4-byte long
+      ipAddr->length = sizeof(Ipv4Addr);
+      //Convert the string to IPv4 address
+      error = ipv4StringToAddr(str, &ipAddr->ipv4Addr);
+   }
+   else
+#endif
+   //Invalid IP address?
+   {
+      //Report an error
+      error = ERROR_FAILURE;
+   }
+
+   //Return status code
+   return error;
+}
+

--- a/src/settings.c
+++ b/src/settings.c
@@ -39,6 +39,7 @@ static void option_map_init(uint8_t settingsId)
     OPTION_TREE_DESC("core.server", "Server ports")
     OPTION_UNSIGNED("core.server.https_port", &settings->core.https_port, 443, 1, 65535, "HTTPS port", "HTTPS port")
     OPTION_UNSIGNED("core.server.http_port", &settings->core.http_port, 80, 1, 65535, "HTTP port", "HTTP port")
+    OPTION_STRING("core.server.bind_ip", &settings->core.bind_ip, "", "Bind IP", "ip for binding the http ports to")
 
     OPTION_TREE_DESC("core.server", "HTTP server")
     OPTION_STRING("core.host_url", &settings->core.host_url, "http://localhost", "Host URL", "URL to teddyCloud server")


### PR DESCRIPTION
As I have the ports 443 and 80 already used by other services on my machine I needed to add a second ip to it and allow teddy cloud to bind its http/https server to that specific ip.

This PR adds the needed possibility to set said ip.