### PR TITLE
initializes cwd buffer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,7 @@ int_t main(int argc, char *argv[])
 
     error_t error = 0;
 
-    char cwd[256];
+    char cwd[256] = {0};
     if (getcwd(cwd, sizeof(cwd)) == NULL)
     {
         get_directory_path(argv[0], cwd, sizeof(cwd));

--- a/src/main.c
+++ b/src/main.c
@@ -7,11 +7,6 @@
 #include <stdint.h>
 #include <math.h>
 
-#ifdef WIN32
-#else
-#include <unistd.h>
-#endif
-
 #include "error.h"
 #include "debug.h"
 #include "cJSON.h"
@@ -28,41 +23,29 @@
 #include "cert.h"
 #include "toniefile.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#define PATH_LEN MAX_PATH
+#else
+#include <unistd.h>
+#include <limits.h>
+#define PATH_LEN PATH_MAX
+#endif
+
+#define DEFAULT_HTTP_PORT 80
+#define DEFAULT_HTTPS_PORT 443
+#define PORT_MAX 65535
+
 void platform_init(void);
 void platform_deinit(void);
 void server_init(void);
-#define DEFAULT_HTTP_PORT 80
-#define DEFAULT_HTTPS_PORT 443
+static char *get_cwd(char *buffer, size_t size);
 
 typedef enum
 {
     PROT_HTTP,
     PROT_HTTPS
 } Protocol;
-
-void get_directory_path(const char *filepath, char *dirpath, int maxLen)
-{
-    // Find the last occurrence of '/' or '\' in the file path
-    int lastSlash = -1;
-    for (int i = 0; filepath[i] != '\0'; i++)
-    {
-        if (filepath[i] == '/' || filepath[i] == '\\')
-        {
-            lastSlash = i;
-        }
-    }
-
-    if (lastSlash == -1)
-    {
-        // No directory part found, use an empty string for the directory path
-        dirpath[0] = '\0';
-    }
-    else
-    {
-        // Copy the characters before the last slash to the directory path buffer
-        snprintf(dirpath, maxLen, "%.*s", lastSlash, filepath);
-    }
-}
 
 bool parse_url(const char *url, char **hostname, uint16_t *port, char **uri, Protocol *protocol)
 {
@@ -98,7 +81,16 @@ bool parse_url(const char *url, char **hostname, uint16_t *port, char **uri, Pro
         strncpy(*hostname, url, hostname_length);
         (*hostname)[hostname_length] = '\0';
 
-        *port = (uint16_t)atoi(port_start + 1);
+        // ensures port is in a valid range before casting
+        long temp = strtol(port_start + 1, NULL, 10);
+        if ((temp >= 0) && (temp <= PORT_MAX))
+        {
+            *port = (uint16_t)temp;
+        }
+        else
+        {
+            *port = (*protocol == PROT_HTTP) ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT;
+        }
     }
     else
     {
@@ -122,14 +114,17 @@ int_t main(int argc, char *argv[])
 
     error_t error = 0;
 
-    char cwd[256] = {0};
-    if (getcwd(cwd, sizeof(cwd)) == NULL)
+    char *cwd = calloc(PATH_LEN, sizeof(char));
+
+    if ((cwd == NULL) || (get_cwd(cwd, PATH_LEN) == NULL))
     {
-        get_directory_path(argv[0], cwd, sizeof(cwd));
+        free(cwd);
+        return -1;
     }
 
     /* platform specific init */
     settings_init(cwd);
+    free(cwd);
     platform_init();
 
     cJSON_Hooks hooks = {.malloc_fn = osAllocMem, .free_fn = osFreeMem};
@@ -340,4 +335,13 @@ int_t main(int argc, char *argv[])
     settings_deinit_all();
 
     return error;
+}
+
+static char *get_cwd(char *buffer, size_t size)
+{
+#ifdef _WIN32
+    return _getcwd(buffer, size);
+#else
+    return getcwd(buffer, size);
+#endif
 }


### PR DESCRIPTION
leaving it uninitialized could lead to a garbage value like a '/' or a '\' to be in the buffer, leading to bugs in get_directory_path() when it searches for the last '/'

Personally i'm not sure why get_directory_path() exists. if the `getcwd()` fails there are a whole host of errors that get_directory_path() doesn't handle. Example: path exceeding 256 bytes. Note: PATH_MAX on linux is 4096 and 260 on windows, so 256 is probably not sufficient here anyways.