### PR TITLE
Issue63

### DIFF
--- a/src/home_assistant.c
+++ b/src/home_assistant.c
@@ -56,7 +56,7 @@ void ha_addstr(char *json_str, const char *name, const char *value, bool last)
 {
     char tmp_buf[128];
 
-    if (value && strlen(value) > 0)
+    if (value)
     {
         osSnprintf(tmp_buf, sizeof(tmp_buf), "\"%s\": \"%s\"%c ", name, value, (last ? ' ' : ','));
         osStrcat(json_str, tmp_buf);

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -141,7 +141,7 @@ error_t mqtt_sendBoxEvent(const char *eventname, const char *content, client_ctx
     case BOX_UNKNOWN:
         break;
     }
-    if (osStrcmp(hw, ha_box->hw) != 0)
+    if (osStrcmp(hw, ha_box->hw) != 0 && osStrlen(ha_box->hw) == 0)
     {
         osSnprintf(ha_box->hw, sizeof(ha_box->hw), "%s", hw);
         updated = true;
@@ -150,7 +150,7 @@ error_t mqtt_sendBoxEvent(const char *eventname, const char *content, client_ctx
     time_t swUa = client_ctx->settings->internal.toniebox_firmware.uaVersionFirmware;
     char *swEsp = client_ctx->settings->internal.toniebox_firmware.uaEsp32Firmware;
 
-    if (osStrlen(version) > 0 && osStrcmp(version, ha_box->sw) != 0)
+    if (osStrlen(version) > 0 && osStrcmp(version, ha_box->sw) != 0 && osStrlen(ha_box->sw) == 0)
     {
         osSnprintf(ha_box->sw, sizeof(ha_box->sw), "%s", version);
         updated = true;
@@ -159,7 +159,7 @@ error_t mqtt_sendBoxEvent(const char *eventname, const char *content, client_ctx
     {
         char sw[MAX_LEN];
         osSnprintf(sw, sizeof(sw), "%" PRIuTIME, swUa);
-        if (osStrcmp(sw, ha_box->sw) != 0)
+        if (osStrcmp(sw, ha_box->sw) != 0 && osStrlen(ha_box->sw) == 0)
         {
             osSnprintf(ha_box->sw, sizeof(ha_box->sw), "%s", sw);
             updated = true;
@@ -167,7 +167,7 @@ error_t mqtt_sendBoxEvent(const char *eventname, const char *content, client_ctx
     }
     else if (client_ctx->settings->internal.toniebox_firmware.uaEsp32Firmware != NULL)
     {
-        if (osStrcmp(swEsp, ha_box->sw) != 0)
+        if (osStrcmp(swEsp, ha_box->sw) != 0 && osStrlen(ha_box->sw) == 0)
         {
             osSnprintf(ha_box->sw, sizeof(ha_box->sw), "%s", swEsp);
             updated = true;


### PR DESCRIPTION
This fixes the none working picture in home assistant. (issue #63 )

The reason why this was not working is some sort of race condition.

The current architecture updates the sw and hw fields of the ha_info class when "mqtt_sendBoxEvent" is called. Here seems to be a problem (which has a root cause I sadly was unable to find due to lack of time). It seems that hw and sw fields are alternating between empty and sane values. This results in 2 things.

1. If hw is empty it will result in invalid json syntax for the home assistant autodiscovery topic (because hw is the last property in the json and is supposed to "close" json struct properly). I fixed this by allowing to publish empty values inside json which is a valid thing to do imo. This leads to valid json even if "hw" property is (still) empty.

3. The fact that the json content is changing all the time (because of alternating hw and sw properties) results in the fact that home assistant updates its internal device structures. It seems it unsubscribes from the topics (state and url) as well and resubscribes to them immediately. The fact that teddycloud pushes its state and url topics (for example the picture url) instantly after publishing the auto discovery topic seems to lead to the fact that home assistant misses that state change of the url. I fixed this by only updating sw and hw fields in case they are still empty. Using retained messages on teddy cloud side might fix this too - but I don't like those messages because the can get messy on the broker ;)

I know that the fix for the 2nd problem is not ideal. No problem if you don't consider this feasible to merge - but I use it for myself so I thought I would at least propose it here. :)