### PR TITLE
Hostname patching for esp32 modified

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -5,6 +5,7 @@ set -o pipefail
 set -o nounset
 # set -o xtrace
 
+mkdir -p /teddycloud/certs/server /teddycloud/certs/client
 
 if [ -n "${DOCKER_TEST:-}" ]; then
   cd /teddycloud

--- a/include/esp32.h
+++ b/include/esp32.h
@@ -14,6 +14,6 @@ error_t esp32_fat_extract(const char *firmware, const char *fat_path, const char
 error_t esp32_fat_inject(const char *firmware, const char *fat_path, const char *in_path);
 error_t esp32_inject_cert(const char *rootPath, const char *patchedPath, const char *mac);
 error_t esp32_inject_ca(const char *rootPath, const char *patchedPath, const char *mac);
-error_t esp32_patch_host(const char *patchedPath, const char *hostname);
+error_t esp32_patch_host(const char *patchedPath, const char *hostname, const char *oldrtnl, const char *oldapi);
 
 uint32_t mem_replace(uint8_t *buffer, size_t buffer_len, const char *pattern, const char *replace);

--- a/src/esp32.c
+++ b/src/esp32.c
@@ -983,7 +983,7 @@ error_t esp32_inject_ca(const char *rootPath, const char *patchedPath, const cha
     return ret;
 }
 
-error_t esp32_patch_host(const char *patchedPath, const char *hostname)
+error_t esp32_patch_host(const char *patchedPath, const char *hostname, const char *oldrtnl, const char *oldapi)
 {
     error_t ret = NO_ERROR;
 
@@ -1026,11 +1026,20 @@ error_t esp32_patch_host(const char *patchedPath, const char *hostname)
             }
         }
         fsCloseFile(bin);
+        
+        if (!strcmp(oldrtnl,oldapi))
+        {
+            int replaced = mem_replace(bin_data, bin_size, oldrtnl, hostname);
+            TRACE_INFO(" replaced hostname %d times\r\n", replaced);
+        }
+        else
+        {
+            int replaced = mem_replace(bin_data, bin_size, oldrtnl, hostname);
+            TRACE_INFO(" replaced RTNL host %d times\r\n", replaced);
+            replaced = mem_replace(bin_data, bin_size, oldapi, hostname);
+            TRACE_INFO(" replaced API host %d times\r\n", replaced);
+        }
 
-        int replaced = mem_replace(bin_data, bin_size, "rtnl.bxcl.de", hostname);
-        TRACE_INFO(" replaced RTNL host %d times\r\n", replaced);
-        replaced = mem_replace(bin_data, bin_size, "prod.de.tbs.toys", hostname);
-        TRACE_INFO(" replaced API host %d times\r\n", replaced);
 
         bin = fsOpenFile(patchedPath, FS_FILE_MODE_WRITE);
         if (!bin)

--- a/src/handler_api.c
+++ b/src/handler_api.c
@@ -983,7 +983,9 @@ error_t handleApiPatchFirmware(HttpConnection *connection, const char_t *uri, co
 
     if (osStrlen(patch_host) > 0)
     {
-        if (esp32_patch_host(patched_path, patch_host) != NO_ERROR)
+        char *oldrtnl = "rtnl.bxcl.de";
+        char *oldapi = "prod.de.tbs.toys";
+        if (esp32_patch_host(patched_path, patch_host, oldrtnl, oldapi) != NO_ERROR)
         {
             TRACE_ERROR("Failed to patch hostnames\r\n");
             return ERROR_NOT_FOUND;

--- a/src/main.c
+++ b/src/main.c
@@ -279,6 +279,28 @@ int_t main(int argc, char *argv[])
             }
             esp32_fixup((const char *)argv[2], true);
         }
+        else if (!strcasecmp(type, "ESP32HOST"))
+        {
+            char *oldrtnl = "rtnl.bxcl.de";
+            char *oldapi = "prod.de.tbs.toys";
+
+            if (argc < 4 || argc > 6)
+            {
+                TRACE_ERROR("Usage: %s ESP32HOST <esp32-image-bin> <hostname> [oldrtnlhost] [oldapihost]\r\n", argv[0]);
+                return -1;
+            }
+            if (argc == 5)
+            {
+                oldrtnl = argv[4];
+                oldapi = argv[4];
+            }
+            if (argc == 6)
+            {
+                oldrtnl = argv[4];
+                oldapi = argv[5];
+            }
+            esp32_patch_host((const char *)argv[2],(const char *)argv[3], oldrtnl, oldapi);
+        }
 #ifdef FFMPEG_DECODING
         else if (!strcasecmp(type, "ENCODE"))
         {
@@ -382,6 +404,7 @@ static void print_usage(char *argv[])
         "  CERTGEN <mac_address> <target_dir>  Generate client certs\r\n"
         "  ESP32CERT (extract/inject) <esp32-image-bin> <source/target-dir>\r\n"
         "  ESP32FIXUP <esp32-image-bin>\r\n"
+        "  ESP32HOST <esp32-image-bin> <hostname> [oldrtnlhost] [oldapihost]   Patch hostname\r\n"
         "  ENCODE_TEST                         Runs an encoding test\r\n"
         "  DOCKER_TEST                         Runs a test to ensure the docker image is fine\r\n",
         argv[0]);


### PR DESCRIPTION
Modified the hostname patching part for the esp32 model so you can specificy what the old hostname to replace is.
Additionally the cli is now able to patch the hostname.