### PR TITLE
Adding files for devcontainer support in vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest as buildenv
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc gdb protobuf-c-compiler build-essential git zip curl
+
+#COPY . /buildenv
+#WORKDIR /buildenv
+#
+#RUN curl -f https://raw.githubusercontent.com/toniebox-reverse-engineering/tonies-json/release/tonies.json -o /buildenv/install/pre/config/tonies.json || true
+#RUN make zip

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  //"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  "name": "teddycloud_build",
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ms-vscode.makefile-tools",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.cpptools-extension-pack"
+      ]
+    }
+  },
+  "forwardPorts": [
+    80,
+    443
+  ],
+  "portsAttributes": {
+    "80": {
+      "label": "Teddycloud webinterface",
+      "onAutoForward": "notify"
+    },
+    "443": {
+      "label": "Teddycloud boxinterface",
+      "onAutoForward": "notify"
+    },
+  }
+  //"postCreateCommand": "yarn install"
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
Hey @SciLor , maybe you want to try this. Working well for me when developing in containers. Needs vscode with the Dev Containers plugin installed. I know from work that there might be speed issues when running from a window ntfs mount, but I can't test due to a lack of windows machines.