### PR TITLE
Dockerfile: Use ubuntu 24.04, expose 8443

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -16,7 +16,7 @@ RUN make zip NO_SANITIZERS=1
 
 # Use Alpine Linux as base image for the final image
 FROM alpine:latest
-EXPOSE 80 443
+EXPOSE 80 443 8443
 
 # Install necessary runtime dependencies
 RUN apk --no-cache add ffmpeg curl ca-certificates bash

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -11,7 +11,7 @@ RUN curl -f https://raw.githubusercontent.com/toniebox-reverse-engineering/tonie
 RUN make zip
 
 FROM debian:latest
-EXPOSE 80 443
+EXPOSE 80 443 8443
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libubsan1 ffmpeg curl ca-certificates \

--- a/DockerfileUbuntu
+++ b/DockerfileUbuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as buildenv
+FROM ubuntu:24.04 as buildenv
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc protobuf-c-compiler build-essential git zip curl
@@ -10,8 +10,8 @@ RUN curl -f https://raw.githubusercontent.com/toniebox-reverse-engineering/tonie
 RUN curl -f https://raw.githubusercontent.com/toniebox-reverse-engineering/tonies-json/release/tonieboxes.json -o /buildenv/contrib/config/tonieboxes.json || true
 RUN make zip
 
-FROM ubuntu:22.04
-EXPOSE 80 443
+FROM ubuntu:24.04
+EXPOSE 80 443 8443
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libubsan1 ffmpeg curl ca-certificates \


### PR DESCRIPTION
Use ubuntu 24.04 to reduce the version skew of dependencies to debian/alpine images.

Also mark port 8443 as exposed.