### PR TITLE
`fopen` handle error

### DIFF
--- a/src/fs_ext.c
+++ b/src/fs_ext.c
@@ -1,11 +1,13 @@
 
 #include "fs_ext.h"
 
+#include <errno.h>           // for errno
 #include <stdint.h>          // for uint8_t
 #include <stdio.h>           // for fopen, FILE
 #include <stdlib.h>          // for NULL, free
-#include <string.h>          // for strdup, strlen, strrchr
+#include <string.h>          // for strdup, strlen, strrchr, strerror
 #include "error.h"           // for NO_ERROR, ERROR_END_OF_FILE, ERROR_FILE_...
+#include "debug.h"           // for TRACE_INFO, TRACE_ERROR, TRACE_LEVEL_INFO
 #include "fs_port_config.h"  // for PATH_SEPARATOR
 #include "os_port.h"         // for osStrlen
 
@@ -36,6 +38,10 @@ FsFile *fsOpenFileEx(const char_t *path, char *mode)
 
     // Open the specified file
     fp = fopen(path, mode);
+
+    if (fp == NULL) {
+        TRACE_ERROR("Could not open file %s: %s\n", path, strerror(errno));
+    }
 
     // Return a handle to the file
     return fp;


### PR DESCRIPTION
While patching the firmware I could not use the web UI, but used the command-line instead. I copied the file into the container (with the `docker cp` command). Somehow this messed up the permissions and the file could not be read by the teddycloud binary. The error message from teddycloud was not helpful  (generic "Failed to read entry" and "Asset partition not found"). 

This is because the error of `fopen` is not handled and it will just fail later in the code, when the extraction tries to access the file descriptor. This patch simply prints the error (but continues execution as before). I guess this is a good first step to help debug problems. In most cases it would probably best to abort the execution, but I'm not familiar with the codebase. Especially if that function is used by the webserver it wouln't be wise to exit.

Output diff.

```diff
 $ ./bin/teddycloud  --esp32-extract ./tb.esp32.bin --destination ./testextract/
 TeddyCloud vX.X.X (1b387da) - 2024-09-25 17:09:55 +0000 ubuntu linux-x86_64(64)
 
 [options] specified 'esp32_extract' as './tb.esp32.bin'
 [options] specified 'destination' as './testextract/'
 INFO |settings.c:0809:settings_load_ovl()| Load settings from /home/$USER/git/teddycloud/config/config.overlay.ini
 INFO |settings.c:0809:settings_load_ovl()| Load settings from /home/$USER/git/teddycloud/config/config.ini
 INFO |settings.c:0809:settings_load_ovl()| Load settings from /home/$USER/git/teddycloud/config/config.overlay.ini
+ERROR|fs_ext.c:0043:fsOpenFileEx()| Could not open file ./tb.esp32.bin: Permission denied
 INFO |esp32.c:1380:esp32_get_partition()| Search for partition 'assets'
 ERROR|esp32.c:1391:esp32_get_partition()| Failed to read entry
 ERROR|esp32.c:1609:esp32_fat_extract()| Asset partition not found
```