### PR TITLE
Link libraries explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ ifneq ($(NO_WARN_FAIL),1)
 endif
 CFLAGS_linux += -ggdb
 CFLAGS_linux += -DFFMPEG_DECODING
+LFLAGS_linux += -pthread -lm
 
 # for now enable extensive error checking
 # Add flags for extensive error checking if NO_SANITIZERS is not set to 1


### PR DESCRIPTION
pthread and libmath are linked implicitly when linking sanitizers. If NO_SANITIZERS is 1, this will lead to a linker error due to the missing libraries.