### PR TITLE
Fix memory leaks

### DIFF
--- a/src/handler_api.c
+++ b/src/handler_api.c
@@ -739,6 +739,7 @@ error_t handleApiFileIndex(HttpConnection *connection, const char_t *uri, const 
 
         if (queryPrepare(queryString, &rootPath, overlay, sizeof(overlay), &client_ctx->settings) != NO_ERROR)
         {
+            osFreeMem(jsonString);
             return ERROR_FAILURE;
         }
 
@@ -881,6 +882,7 @@ error_t handleApiFileIndex(HttpConnection *connection, const char_t *uri, const 
         }
 
         osFreeMem(pathAbsolute);
+        osFreeMem(jsonString);
         jsonString = cJSON_PrintUnformatted(json);
         cJSON_Delete(json);
     } while (0);

--- a/src/json_helper.c
+++ b/src/json_helper.c
@@ -53,7 +53,10 @@ cJSON *jsonAddByteArrayToObject(cJSON *const object, const char *const name, uin
         sprintf(&string[i * 2], "%02hhx", bytes[i]);
     }
 
-    return cJSON_AddStringToObject(object, name, string);
+    // temporary object is needed, so we can free string, because of lack of RAII
+    cJSON *tmpObject = cJSON_AddStringToObject(object, name, string);
+    osFreeMem(string);
+    return tmpObject;
 }
 
 bool_t jsonGetBool(cJSON *jsonElement, char *name)

--- a/src/main.c
+++ b/src/main.c
@@ -222,6 +222,7 @@ void set_settings(const char *option)
     {
         TRACE_ERROR("Invalid config-set option format. Expected name=value.\r\n");
     }
+    osFreeMem(data);
 }
 
 void exit_cleanup(int exit_code)

--- a/src/tonie_audio_playlist.c
+++ b/src/tonie_audio_playlist.c
@@ -189,6 +189,8 @@ error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bo
         char source[99][PATH_LEN];
         if (tap->filesCount == 0)
         {
+            osFreeMem(tmp_taf);
+            freeTonieInfo(tonieInfo);
             return ERROR_INVALID_FILE;
         }
 


### PR DESCRIPTION
Reopened pull request #256
The pull request is now targeting develop, it has been rebased on develop.

There were 5 memory leaks, which were caught by the tool: infer and clang-tidy

1. src/handler_api.c was an exit path before the free and a forgotten free
2. src/json_helper.c Is now a rather ugly construct, but is necessary so the variable named string can be freed.
3. src/main.c a forgotten free
4. src/tonie_audio_playlist.c an exit path without freeing allocs

It must be mentioned though, that some more tweaking should be done, as osAllocMem could actually fail (unlikely, but not unheard). Return values of allocations are nowhere really handled, so this PR just addresses the obvious memory leaking.
