### PR TITLE
Update docker-compose.yaml, remove yaml version info

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   teddycloud:
     container_name: teddycloud


### PR DESCRIPTION
Remove deprecated docker-compose version of the yaml file.

At the moment this is only a warning, e.g. when shutting down the container:

```
$ docker-compose down
WARN[0000] $HOME/teddycloud/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```