### PR TITLE
Fix serial number in CA root certificate

### DIFF
--- a/src/cert.c
+++ b/src/cert.c
@@ -429,10 +429,7 @@ error_t cert_generate_default()
 
     if (error_ca != NO_ERROR || error_ca_key != NO_ERROR)
     {
-
-        /* create a proper ASN.1 compatible serial with no leading zeroes */
         cert_generate_serial(serial, &serial_length);
-        serial[0] = 0x00;
 
         TRACE_INFO("Generating CA certificate...\r\n");
         if (cert_generate_signed("TeddyCloud CA Root Cert.", serial, serial_length, CA_RSA_SIZE, true, false, cacert, cacert_key) != NO_ERROR)


### PR DESCRIPTION
The CA root certificate generated by teddycloud is invalid (see #230). The certificate is neither recognised by the browser nor can openssl read the certificate. The root of the problem is an invalid serial number in the CA root certificate as @brechsteiner pointed out.

This PR fixes the serial number generation for the CA certificate. 