### PR TITLE
 Fixes docker warning in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,21 @@
 FROM ubuntu:latest AS buildenv
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc gdb protobuf-c-compiler build-essential git zip curl
+    && apt-get install -y --no-install-recommends \
+        gcc \
+        gdb \
+        protobuf-c-compiler \
+        build-essential \
+        git \
+        zip \
+        curl \
+        ca-certificates \
+        openssl \
+        faketime \
+        python3 \
+        python3-dotenv-cli \
+        nodejs \
+        npm
 
 #COPY . /buildenv
 #WORKDIR /buildenv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as buildenv
+FROM ubuntu:latest AS buildenv
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc gdb protobuf-c-compiler build-essential git zip curl


### PR DESCRIPTION
Starting devcontainer showed `FromAsCasing: 'as' and 'FROM' keywords' casing do not match`


Also when trying to change something and build in the devcontainer   make failed as tools were missing so i added them to the container `make all` now  works inside the devcontainer environment