### PR TITLE
docker: support running as non-root via PUID/PGID

### DIFF
--- a/DockerfileAlpine
+++ b/DockerfileAlpine
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.version=$TEDDYCLOUD_VERSION
 EXPOSE 80 443 8443
 
 # Install necessary runtime dependencies
-RUN apk --no-cache add strace ffmpeg curl ca-certificates bash
+RUN apk --no-cache add strace ffmpeg curl ca-certificates bash su-exec shadow libcap
 
 # Update CA certificates
 RUN update-ca-certificates
@@ -48,6 +48,10 @@ COPY --from=buildenv /buildenv/install/pre/certs/ /teddycloud/certs/
 COPY --from=buildenv /buildenv/install/pre/data/www/ /teddycloud/data/www/
 COPY --from=buildenv /buildenv/install/pre/*.sh /usr/local/bin/
 COPY --from=buildenv /buildenv/install/pre/teddycloud /usr/local/bin/teddycloud
+
+# Allow non-root user to bind privileged ports (80, 443) when PUID/PGID are set
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/teddycloud
+
 COPY --from=buildenv /buildenv/install/zip/release.zip /tmp/teddycloud.zip
 
 # Set up volumes

--- a/DockerfileDebian
+++ b/DockerfileDebian
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.version=$TEDDYCLOUD_VERSION
 EXPOSE 80 443 8443
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libubsan1 strace ffmpeg curl ca-certificates \
+    && apt-get install -y --no-install-recommends libubsan1 strace ffmpeg curl ca-certificates gosu libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates
@@ -46,6 +46,9 @@ COPY --from=buildenv \
     /buildenv/install/pre/*.sh /usr/local/bin/
 COPY --from=buildenv \
     /buildenv/install/pre/teddycloud /usr/local/bin/teddycloud
+
+# Allow non-root user to bind privileged ports (80, 443) when PUID/PGID are set
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/teddycloud
 
 COPY --from=buildenv /buildenv/install/zip/release.zip /tmp/teddycloud.zip
 

--- a/DockerfileUbuntu
+++ b/DockerfileUbuntu
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.version=$TEDDYCLOUD_VERSION
 EXPOSE 80 443 8443
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libubsan1 strace ffmpeg curl ca-certificates \
+    && apt-get install -y --no-install-recommends libubsan1 strace ffmpeg curl ca-certificates gosu libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates
@@ -46,6 +46,9 @@ COPY --from=buildenv \
     /buildenv/install/pre/*.sh /usr/local/bin/
 COPY --from=buildenv \
     /buildenv/install/pre/teddycloud /usr/local/bin/teddycloud
+
+# Allow non-root user to bind privileged ports (80, 443) when PUID/PGID are set
+RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/teddycloud
 
 COPY --from=buildenv /buildenv/install/zip/release.zip /tmp/teddycloud.zip
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     container_name: teddycloud
     hostname: teddycloud
     image: ghcr.io/toniebox-reverse-engineering/teddycloud:latest
+    # environment:
+    #  - PUID=1000 #optional (run as non-root; UID for /teddycloud files)
+    #  - PGID=1000 #optional (run as non-root; GID for /teddycloud files)
     # ports:
     #  - 80:80 #optional (for the webinterface)
     #  - 8443:8443 #optional (for the webinterface)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,18 +8,53 @@ set -o nounset
 mkdir -p /teddycloud/certs/server /teddycloud/certs/client
 cd /teddycloud
 
+# PUID/PGID support: if set and non-zero, drop privileges to that user before
+# running teddycloud. When unset or 0, behavior is unchanged (runs as root).
+#
+# This pairs with `setcap 'cap_net_bind_service=+ep'` on /usr/local/bin/teddycloud
+# in the Dockerfile so the non-root user can still bind ports 80/443.
+RUN_AS=()
+if [ -n "${PUID:-}" ] && [ -n "${PGID:-}" ] && [ "${PUID}" != "0" ] && [ "${PGID}" != "0" ]; then
+  # Pick whichever drop-privs helper is installed: gosu (Debian/Ubuntu) or
+  # su-exec (Alpine). Both have the same calling convention (`<helper> user cmd...`).
+  if command -v gosu >/dev/null 2>&1; then
+    DROP_PRIVS="gosu"
+  elif command -v su-exec >/dev/null 2>&1; then
+    DROP_PRIVS="su-exec"
+  else
+    echo "PUID/PGID set but neither gosu nor su-exec is installed; cannot drop privileges." >&2
+    exit 1
+  fi
+
+  # Create or reconcile the teddy group/user with the requested ids. The
+  # `|| ... ||  true` chain handles re-runs (user/group already exists at the
+  # right ids) without failing the entrypoint.
+  groupadd -g "${PGID}" teddy 2>/dev/null \
+    || groupmod -o -g "${PGID}" teddy 2>/dev/null \
+    || true
+  useradd -u "${PUID}" -g "${PGID}" -M -s /bin/bash teddy 2>/dev/null \
+    || usermod -o -u "${PUID}" -g "${PGID}" teddy 2>/dev/null \
+    || true
+
+  echo "Adjusting /teddycloud ownership to ${PUID}:${PGID}..."
+  chown -R "${PUID}:${PGID}" /teddycloud
+
+  RUN_AS=("${DROP_PRIVS}" "teddy")
+  echo "Will run teddycloud as ${PUID}:${PGID} via ${DROP_PRIVS}"
+fi
+
 if [ -n "${DOCKER_TEST:-}" ]; then
   echo "Running teddycloud --docker-test..."
-  LSAN_OPTIONS=detect_leaks=0 teddycloud --docker-test
+  LSAN_OPTIONS=detect_leaks=0 "${RUN_AS[@]}" teddycloud --docker-test
 else
   while true
   do
     if [ -n "${STRACE:-}" ]; then
       echo "Running teddycloud with strace..."
-      strace -t -T teddycloud
-    else 
+      "${RUN_AS[@]}" strace -t -T teddycloud
+    else
       echo "Running teddycloud..."
-      teddycloud
+      "${RUN_AS[@]}" teddycloud
     fi
     retVal=$?
     echo "teddycloud exited with code $retVal"


### PR DESCRIPTION
Closes #441.

Wires up the standard PUID/PGID convention so the container can drop privileges to a host user, leaving bind-mounted files owned by that user instead of root.

## Behavior

- **Unset or `PUID=0` / `PGID=0`** (default): container runs as root, exactly like today. No behavioral change for existing users.
- **`PUID` and `PGID` set to non-zero values**: the entrypoint creates a `teddy` user with that UID/GID, chowns `/teddycloud` to it once at startup, then drops privileges (`gosu` on Debian/Ubuntu, `su-exec` on Alpine) before running the daemon. Files written to bind-mounted host paths (catalog, library, etc.) end up owned by the host user.

## Privileged port binding

teddycloud binds 80 and 443 (the box's mTLS API), which a non-root user can't normally do. Handled with `setcap 'cap_net_bind_service=+ep'` on the binary in each Dockerfile.

## Files changed

- `DockerfileUbuntu`, `DockerfileDebian`: install `gosu` + `libcap2-bin`, add `setcap` line
- `DockerfileAlpine`: install `su-exec` + `shadow` (for groupadd/useradd) + `libcap`, add `setcap` line
- `docker/docker-entrypoint.sh`: detect `gosu` vs `su-exec` at runtime, create teddy user, chown, drop privileges before exec

## Test plan

- [ ] Container starts cleanly with PUID/PGID unset (regression check)
- [ ] Container starts cleanly with PUID=1000, PGID=1000; \`docker exec teddycloud id\` shows uid=1000
- [ ] Toniebox can connect (mTLS on :443) under non-root mode — confirms setcap works
- [ ] Files written to bind-mounted /teddycloud/config/tonies.custom.json land 1000:1000 on host
- [ ] All three image variants (Ubuntu/Debian/Alpine) build and behave identically

Marked draft for review of the entrypoint approach before polish.