### PR TITLE
docker: fix entrypoint in-place restart loop

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -47,8 +47,17 @@ if [ -n "${DOCKER_TEST:-}" ]; then
   echo "Running teddycloud --docker-test..."
   LSAN_OPTIONS=detect_leaks=0 "${RUN_AS[@]}" teddycloud --docker-test
 else
+  # teddycloud requests an in-place restart by exiting with RETURNCODE_USER_RESTART
+  # (-2 in the source), which the shell receives as the unsigned 8-bit code 254.
+  # Restart the process on that code; for any other exit code, leave the loop and
+  # let Docker's restart policy (if configured) decide what happens next.
+  readonly RESTART_CODE=254
   while true
   do
+    # Disable errexit only around the long-running process: a non-zero exit (a
+    # crash, or a user-requested restart/quit) must NOT abort the loop before we
+    # have inspected the exit code below.
+    set +o errexit
     if [ -n "${STRACE:-}" ]; then
       echo "Running teddycloud with strace..."
       "${RUN_AS[@]}" strace -t -T teddycloud
@@ -57,9 +66,10 @@ else
       "${RUN_AS[@]}" teddycloud
     fi
     retVal=$?
+    set -o errexit
     echo "teddycloud exited with code $retVal"
-    if [ $retVal -ne -2 ]; then
-      exit $retVal
+    if [ "$retVal" -ne "$RESTART_CODE" ]; then
+      exit "$retVal"
     fi
     echo "Restarting teddycloud..."
   done


### PR DESCRIPTION
Fixes #448

### Problem

`docker/docker-entrypoint.sh` could never restart `teddycloud` in place:

1. `set -o errexit` is active, so the script terminated the instant `teddycloud` exited non-zero — before `retVal=$?` and the restart check ran.
2. The check compared the exit code against `-2`, but `teddycloud` exits with `internal.returncode` (`src/server.c:1058` → `exit(ret)`), and the web UI restart action sets that to `RETURNCODE_USER_RESTART = -2` (`src/handler_api.c:421`). A `-2` process exit reaches the shell as the unsigned 8-bit value **254**, so the comparison never matched.

Net effect: the web UI "restart" never restarted the process in place; the container exited and only recovered if a Docker `--restart` policy happened to be set.

### Fix

- Temporarily disable `errexit` around the long-running `teddycloud` invocation so its exit code can be inspected.
- Compare against `254` (the 8-bit form of `RETURNCODE_USER_RESTART`) and restart on that; every other exit code leaves the loop exactly as before.

### Testing

There is no shell-test harness in the repo, so verification was:

- `bash -n docker/docker-entrypoint.sh` — passes.
- Manual: a wrapper that `exit`s `254` is restarted in place by the loop; other codes (`0`, `1`, `139`, `255`) cause the script to exit with that code (unchanged behavior). The `DOCKER_TEST` one-shot branch is untouched.

Targeted at `develop` per the contribution guidelines.