### PR TITLE
settings: enforce min/max bounds when loading numeric config values

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -1008,6 +1008,9 @@ static error_t settings_load_ovl(bool overlay)
                     setting_item_t *opt = settings_get_by_name_ovl(option_name, overlay_unique_id);
                     if (opt != NULL)
                     {
+                        // temporaries for the bounds-checked numeric cases below
+                        int32_t signedVal;
+                        uint32_t unsignedVal;
                         // Update the setting value based on the type
                         if (overlay)
                         {
@@ -1025,12 +1028,40 @@ static error_t settings_load_ovl(bool overlay)
                             TRACE_DEBUG("%s=%s\r\n", opt->option_name, *((bool *)opt->ptr) ? "true" : "false");
                             break;
                         case TYPE_SIGNED:
-                            *((int32_t *)opt->ptr) = atoi(value_str);
+                            // Enforce the same min/max bounds the API setters apply, but only
+                            // when the option declares a real range (max > min). Options left
+                            // unbounded (e.g. internal counters with min == max) keep the raw
+                            // value, preserving previous behaviour.
+                            signedVal = atoi(value_str);
+                            if (opt->max.signed_value > opt->min.signed_value &&
+                                (signedVal < opt->min.signed_value || signedVal > opt->max.signed_value))
+                            {
+                                TRACE_WARNING("Value %d for '%s' out of range [%d, %d]; keeping %d\r\n",
+                                              signedVal, option_name, opt->min.signed_value,
+                                              opt->max.signed_value, *((int32_t *)opt->ptr));
+                            }
+                            else
+                            {
+                                *((int32_t *)opt->ptr) = signedVal;
+                            }
                             TRACE_DEBUG("%s=%d\r\n", opt->option_name, *((int32_t *)opt->ptr));
                             break;
                         case TYPE_UNSIGNED:
                         case TYPE_HEX:
-                            *((uint32_t *)opt->ptr) = strtoul(value_str, NULL, 10);
+                            unsignedVal = strtoul(value_str, NULL, 10);
+                            if (opt->max.unsigned_value > opt->min.unsigned_value &&
+                                (unsignedVal < opt->min.unsigned_value || unsignedVal > opt->max.unsigned_value))
+                            {
+                                TRACE_WARNING("Value %u for '%s' out of range [%llu, %llu]; keeping %u\r\n",
+                                              unsignedVal, option_name,
+                                              (unsigned long long)opt->min.unsigned_value,
+                                              (unsigned long long)opt->max.unsigned_value,
+                                              *((uint32_t *)opt->ptr));
+                            }
+                            else
+                            {
+                                *((uint32_t *)opt->ptr) = unsignedVal;
+                            }
                             TRACE_DEBUG("%s=%u\r\n", opt->option_name, *((uint32_t *)opt->ptr));
                             break;
                         case TYPE_FLOAT:


### PR DESCRIPTION
Fixes #451

### Problem

The API setters (`settings_set_signed_id` / `settings_set_unsigned_id`) reject out-of-range values, but the config-file load path (`settings_load_ovl`, `src/settings.c`) wrote parsed values straight to the struct:

```c
case TYPE_SIGNED:
    *((int32_t *)opt->ptr) = atoi(value_str);
    break;
case TYPE_UNSIGNED:
case TYPE_HEX:
    *((uint32_t *)opt->ptr) = strtoul(value_str, NULL, 10);
    break;
```

So a hand-edited or corrupted `config.ini` / `config.overlay.ini` could set values outside an option's documented range.

### Fix

Apply the same bounds check on load. Importantly, it only kicks in when the option declares a **real range (`max > min`)**, so unbounded internal options keep their raw value — e.g. `internal.security_mit.blacklisted_domain_access` has `min == max == 0`, and several internal counters/timestamps use `UINT64_MAX` maxima. On an out-of-range value it warns and keeps the current/default (matching the setters, which reject rather than write).

### Testing

No unit-test harness exists for the C side, so this was verified by compiling the `buildenv` stage of `DockerfileUbuntu` (linux/arm64): `src/settings.c` builds with **0 warnings and 0 errors** (the new `uint64_t` min/max are printed with `%llu` to stay `-Wformat`-clean).

Targeted at `develop`.