### PR TITLE
fs: raise FS_MAX_NAME_LEN to 255 so long library filenames resolve

### DIFF
--- a/include/fs_port_config.h
+++ b/include/fs_port_config.h
@@ -5,3 +5,9 @@
 #else
 #define PATH_SEPARATOR PATH_SEPARATOR_LINUX
 #endif
+
+// Raise the maximum filename length from the cyclone default of 127 so long
+// library/tonie filenames resolve (issue #374). cyclone/common/fs_port.h includes
+// this config header before its own `#ifndef FS_MAX_NAME_LEN` guard, so defining
+// it here cleanly overrides the default without patching the vendored header.
+#define FS_MAX_NAME_LEN 255


### PR DESCRIPTION
Fixes #374

### Problem
`FsDirEntry.name` is sized by `FS_MAX_NAME_LEN` (127). `fsReadDir` truncates any longer name, so a library file with a long name (the reporter's was ~136 chars) is truncated in the file index. The truncated name no longer matches a real path, so `getTonieInfo` can't open the TAF — and the cover image, model/episode and play button all come up empty.

### Fix
Raise `FS_MAX_NAME_LEN` to 255 (the usual filesystem `NAME_MAX`) in the patched `src/cyclone/common/fs_port.h`, which the build prefers over the submodule copy via the `-Isrc/cyclone/common` include order. `FsDirEntry.name` becomes `[256]`, preserving names up to 255 chars.

### Testing
Compiles clean with `-Werror` (Docker `buildenv`, linux/arm64). Verifiable by dropping a TAF with a >127-char name into `data/library` and confirming the file-index API returns the full name and resolves its metadata.

Targeted at `develop`.