### PR TITLE
handler_api: read the full POST body in parsePostData (fix Firefox upload/encode)

### DIFF
--- a/src/handler_api.c
+++ b/src/handler_api.c
@@ -36,13 +36,26 @@ error_t parsePostData(HttpConnection *connection, char_t *post_data, size_t buff
         TRACE_ERROR("Body size %" PRIuSIZE " bigger than buffer size %" PRIuSIZE " bytes\r\n", connection->request.byteCount, buffer_size);
         return ERROR_BUFFER_OVERFLOW;
     }
-    error = httpReceive(connection, post_data, buffer_size, &size, 0x00);
-    if (error != NO_ERROR)
+    /* The body may arrive across multiple TCP segments (e.g. Firefox commonly
+       sends the POST body separately from the headers), so a single httpReceive()
+       can return only the first chunk and silently truncate the body. Loop until
+       the full Content-Length has been read. See teddycloud_web#171. */
+    size_t received = 0;
+    while (received < connection->request.byteCount)
     {
-        TRACE_ERROR("Could not read post data\r\n");
-        return error;
+        error = httpReceive(connection, post_data + received, buffer_size - received, &size, 0x00);
+        if (error != NO_ERROR)
+        {
+            TRACE_ERROR("Could not read post data (got %" PRIuSIZE " of %" PRIuSIZE " bytes)\r\n", received, connection->request.byteCount);
+            return error;
+        }
+        if (size == 0)
+        {
+            break;
+        }
+        received += size;
     }
-    return error;
+    return NO_ERROR;
 }
 
 /* sanitizes the path - needs two additional characters in worst case, so make sure 'path' has enough space */


### PR DESCRIPTION
Fixes toniebox-reverse-engineering/teddycloud_web#171

### Problem
`parsePostData()` did a single `httpReceive()`, which returns only the first TCP segment of the body. When the body arrives in a separate segment — common with **Firefox** — it's truncated. In the "convert to TAF" flow the `&target=…` param is appended last, so it gets dropped → `queryGet(..., "target", ...)` fails → HTTP 400 ("target missing!"). (Filed on teddycloud_web, but the defect is in the C backend.)

### Fix
Loop `httpReceive()` until the full `connection->request.byteCount` has been read (or the connection closes). This also hardens every other caller of `parsePostData`.

### Testing
Compiles clean with `-Werror` (Docker `buildenv`, linux/arm64). Reproducible by sending a POST whose body arrives in a second segment (segmented `curl`), which previously truncated and now reads fully.

> A separate body read in `handleApiSettingsSet` (`~handler_api.c:513`) has the same single-read pattern; kept out of scope here but happy to follow up.

Targeted at `develop`.