### PR TITLE
cache: free cache entries on shutdown (cache_deinit)

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -91,4 +91,9 @@ cache_entry_t *cache_fetch_by_path(const char *path);
  */
 cache_entry_t *cache_fetch_by_cached_url(const char *cached_url);
 
+/**
+ * @brief Frees all cache entries and their strings. Call once on shutdown.
+ */
+void cache_deinit(void);
+
 #endif // _CACHE_H

--- a/src/cache.c
+++ b/src/cache.c
@@ -204,6 +204,25 @@ cache_entry_t *cache_add(const char *url)
     return entry;
 }
 
+void cache_deinit(void)
+{
+    /* The cache list lives for the whole process; free it on shutdown so the
+       entries and their strdup'd strings aren't reported as leaks. cache_table
+       itself is a static head node, so only walk and free the .next chain.
+       Runs single-threaded during shutdown, after the HTTP server has stopped. */
+    cache_entry_t *pos = cache_table.next;
+    while (pos)
+    {
+        cache_entry_t *next = pos->next;
+        osFreeMem((void *)pos->original_url);
+        osFreeMem((void *)pos->cached_url);
+        osFreeMem((void *)pos->file_path);
+        osFreeMem(pos);
+        pos = next;
+    }
+    cache_table.next = NULL;
+}
+
 bool cache_fetch_entry(cache_entry_t *entry)
 {
     if (entry->exists && fsFileExists(entry->file_path))

--- a/src/server.c
+++ b/src/server.c
@@ -1048,6 +1048,7 @@ void server_init(bool test)
     }
     mqtt_server_deinit();
     tonies_deinit();
+    cache_deinit();
     mutex_manager_deinit();
 
     pcaplog_close();


### PR DESCRIPTION
Fixes #304

### Problem
The image/content cache list (`cache_table` in `cache.c`) is populated at startup from `tonies.json` and lives for the whole process, but there's **no deinit** — so every `cache_entry_t` and its three `strdup()`'d strings (`original_url`, `cached_url`, `file_path`) are still allocated at exit. That's the bulk of the LeakSanitizer report in #304 (~tens of thousands of allocations).

### Fix
Add `cache_deinit()` that walks the list and frees each entry + its strings, and call it from the shutdown path in `server.c` next to `tonies_deinit()`. `cache_table` is a static head node, so only the `.next` chain is freed. It runs single-threaded during shutdown (after the HTTP server has stopped), so no locking is needed.

### Scope / follow-up
This fixes the dominant, always-present startup leak. There's a smaller, separate re-leak on the `cache_entry_add` duplicate path (a freshly-allocated entry isn't freed when a duplicate is detected on reload) — fixing that cleanly needs a small `cache_add` API change (return the existing entry), so I left it out of this focused PR. Happy to follow up.

### Testing
Compiles clean with `-Werror` (Docker `buildenv`, linux/arm64). The freed set is exactly what `cache_add`/`cache_entry_add` allocate; LSan confirmation needs the default ASan build (broken on this arm64 host), so verified by inspection + compile.

Targeted at `develop`.