### PR TITLE
Keep TAP generation alive after client disconnect

### DIFF
--- a/include/tonie_audio_playlist.h
+++ b/include/tonie_audio_playlist.h
@@ -27,11 +27,12 @@ typedef struct
 {
     tonie_audio_playlist_t *tap;
     bool_t force;
+    bool_t preserve_on_client_disconnect;
 } tap_generate_param_t;
 
 bool_t is_valid_tap(char *filename);
 error_t tap_load(char *filename, tonie_audio_playlist_t *tap);
 error_t tap_save(char *filename, tonie_audio_playlist_t *tap);
 void tap_free(tonie_audio_playlist_t *tap);
-error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bool_t *active, bool_t force);
+error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bool_t *active, bool_t force, bool_t preserve_on_client_disconnect);
 void tap_generate_task(void *param);

--- a/include/toniefile.h
+++ b/include/toniefile.h
@@ -40,6 +40,7 @@ typedef struct
     OsTaskId taskId;
     bool_t quit;
     bool_t stop_on_playback_stop;
+    bool_t client_disconnected;
     OsTaskParameters taskParams;
     void *ctx;
 } stream_ctx_t;

--- a/src/handler_cloud.c
+++ b/src/handler_cloud.c
@@ -698,12 +698,14 @@ error_t handleCloudContentExt(HttpConnection *connection, const char_t *uri, con
         tap_param.tap = &tonieInfo->json._tap;
         tap_param.tap->audio_id = time(NULL) - TEDDY_BENCH_AUDIO_ID_DEDUCT;
         tap_param.force = false;
+        tap_param.preserve_on_client_disconnect = true;
 
         stream_ctx_t *stream_ctx = &client_ctx->state->box.stream_ctx;
         stream_ctx->active = false;
         stream_ctx->quit = false;
         stream_ctx->error = NO_ERROR;
-        stream_ctx->stop_on_playback_stop = true;
+        stream_ctx->client_disconnected = false;
+        stream_ctx->stop_on_playback_stop = false;
         stream_ctx->ctx = &tap_param;
         stream_ctx->taskParams.stackSize = 10 * 1024;
         stream_ctx->taskParams.priority = 0;
@@ -717,9 +719,17 @@ error_t handleCloudContentExt(HttpConnection *connection, const char_t *uri, con
         if (stream_ctx->error == NO_ERROR)
         {
             error_t response_error = httpSendResponseStream(connection, streamFileRel, true);
-            if (response_error)
+                        if (response_error)
             {
-                TRACE_ERROR(" >> file %s not available or not send, error=%s...\r\n", tonieInfo->contentPath, error2text(response_error));
+                if (response_error == ERROR_TIMEOUT && stream_ctx->error == NO_ERROR && !stream_ctx->quit)
+                {
+                    stream_ctx->client_disconnected = true;
+                    TRACE_WARNING(" >> TAP stream client timeout/disconnect while TAF generation is still active; preserving background generation\r\n");
+                }
+                else
+                {
+                    TRACE_ERROR(" >> file %s not available or not send, error=%s...\r\n", tonieInfo->contentPath, error2text(response_error));
+                }
             }
         }
         else
@@ -727,7 +737,10 @@ error_t handleCloudContentExt(HttpConnection *connection, const char_t *uri, con
             TRACE_ERROR(" >> TAP stream not available, error=%s...\r\n", error2text(stream_ctx->error));
         }
 
-        stream_ctx->active = false;
+        if (!stream_ctx->client_disconnected)
+        {
+            stream_ctx->active = false;
+        }
 
         while (!stream_ctx->quit)
         {

--- a/src/tonie_audio_playlist.c
+++ b/src/tonie_audio_playlist.c
@@ -176,7 +176,7 @@ void tap_free(tonie_audio_playlist_t *tap)
     osMemset(tap, 0, sizeof(tonie_audio_playlist_t));
 }
 
-error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bool_t *active, bool_t force)
+error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bool_t *active, bool_t force, bool_t preserve_on_client_disconnect)
 {
     error_t error = NO_ERROR;
     bool_t sweep = false;
@@ -199,9 +199,9 @@ error_t tap_generate_taf(tonie_audio_playlist_t *tap, size_t *current_source, bo
             osStrcpy(source[i], tap->files[i]._filepath_resolved);
         }
         // toniefile_t *taf = toniefile_create(tmp_taf, tap->audio_id, false, 0);
-        error = ffmpeg_stream(source, tap->filesCount, current_source, tmp_taf, 0, active, &sweep, false, false);
+        error = ffmpeg_stream(source, tap->filesCount, current_source, tmp_taf, 0, active, &sweep, false, preserve_on_client_disconnect);
         // toniefile_close(taf);
-        if (error != NO_ERROR)
+        if (error != NO_ERROR && !preserve_on_client_disconnect)
         {
             fsDeleteFile(tmp_taf);
         }
@@ -220,7 +220,7 @@ void tap_generate_task(void *param)
     stream_ctx_t *stream_ctx = (stream_ctx_t *)param;
     tap_generate_param_t *tap_ctx = (tap_generate_param_t *)stream_ctx->ctx;
 
-    stream_ctx->error = tap_generate_taf(tap_ctx->tap, &stream_ctx->current_source, &stream_ctx->active, tap_ctx->force);
+    stream_ctx->error = tap_generate_taf(tap_ctx->tap, &stream_ctx->current_source, &stream_ctx->active, tap_ctx->force, tap_ctx->preserve_on_client_disconnect);
     stream_ctx->quit = true;
     osDeleteTask((OsTaskId) OS_SELF_TASK_ID);
 }


### PR DESCRIPTION
## Summary

Keep TAP-to-TAF generation alive when the HTTP client times out or disconnects while a generated TAP stream is still being produced.

Generated TAP streams are written to a temporary `.taf.tmp` file while the client request is already being served from that same growing file. For larger playlists, the HTTP delivery path can time out before the temporary TAF generation has completed.

Previously, that delivery timeout was treated like a fatal stream failure. This stopped the stream context, closed the ffmpeg pipe, and caused the in-progress temporary TAF to be deleted, even though TAP-to-TAF generation itself could still be valid.

## Problem

This is a lifecycle race between two separate parts of the generated TAP stream path:

1. the TAP-to-TAF producer
2. the HTTP delivery consumer

The observed failure sequence was:

```text
client requests generated TAP content
TeddyCloud starts generating <tap>.taf.tmp
httpSendResponseStream() serves the still-growing temporary TAF
HTTP delivery times out while generation is still active
the stream context is stopped
ffmpeg loses its consumer and fails with Broken pipe
the temporary TAF is considered invalid and deleted
```

So a client-side delivery timeout could turn into a TAP generation failure.

## What changed

This change adds explicit state for client disconnects/timeouts during streaming TAP generation.

`stream_ctx_t` now tracks whether the client disconnected while the stream was being served.

The TAP generation task receives a `preserve_on_client_disconnect` flag, which allows it to preserve the temporary TAF only for this specific case.

The HTTP handler now treats `ERROR_TIMEOUT` as a client disconnect only when all of the following are true:

```c
response_error == ERROR_TIMEOUT &&
stream_ctx->error == NO_ERROR &&
!stream_ctx->quit
```

This keeps the handling narrow:

* only HTTP delivery timeouts are treated this way
* only while TAP-to-TAF generation has not reported an error
* only while the generation task has not finished
* other response errors still follow the existing error path
* actual generation failures still clean up normally

## Why this is safe

This does not blindly ignore timeouts.

The timeout is only preserved when it happens while generated TAP content is still being produced and the generator has not reported an error.

In that case, the timeout belongs to the HTTP delivery side, not necessarily to the TAP generation side.

In short:

```text
HTTP delivery timeout during active TAP generation != TAP generation failure
```

If the generator itself fails, or if the generation task has already quit, the existing error handling remains unchanged.

## Practical effect

In local testing with generated TAP playlists, this prevents the server from aborting TAP generation when the client delivery path times out during temporary TAF generation.

It also avoids closing the ffmpeg pipe prematurely, which previously caused:

```text
Broken pipe
TAF encoding failed, deleting TAF
```

The generated temporary TAF can continue to completion instead of being discarded due to a client-side delivery timeout.

## Scope

The change is limited to generated TAP streams and the TAP generation path.

It does not change normal local TAF delivery, cloud fallback behavior, or generic HTTP streaming behavior.
