### PR TITLE
Re-enable AddressSanitizer on aarch64 via native arm64 runners

### DIFF
--- a/.github/workflows/publish_docker_matrix_all.yml
+++ b/.github/workflows/publish_docker_matrix_all.yml
@@ -48,7 +48,8 @@ jobs:
       platforms: '["linux/amd64", "linux/arm/v7", "linux/arm64/v8", "linux/ppc64le", "linux/s390x"]'
       primary_image: true
       error_platforms: '["linux/s390x"]'
-      noasan_fallback_platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      # arm64 builds with AddressSanitizer (native runner, see base workflow).
+      noasan_fallback_platforms: '["linux/arm/v7", "linux/ppc64le"]'
       tcw_commit_hash: ${{ inputs.tcw_commit_hash }}
   debian:
     needs: test_commit_hash
@@ -59,7 +60,8 @@ jobs:
       platforms: '["linux/amd64", "linux/arm/v7", "linux/arm64/v8", "linux/i386", "linux/ppc64le", "linux/s390x"]'
       primary_image: false
       error_platforms: '["linux/s390x"]'
-      noasan_fallback_platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      # arm64 builds with AddressSanitizer (native runner, see base workflow).
+      noasan_fallback_platforms: '["linux/arm/v7", "linux/ppc64le"]'
       tcw_commit_hash: ${{ inputs.tcw_commit_hash }}
   alpine:
     needs: test_commit_hash
@@ -79,9 +81,10 @@ jobs:
     with:
       system: "ubuntuAsanTest"
       dockerfile: "DockerfileUbuntu"
-      platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      # arm64 is promoted to the main build; these remain ASAN-broken under QEMU.
+      platforms: '["linux/arm/v7", "linux/ppc64le"]'
       primary_image: false
-      error_platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      error_platforms: '["linux/arm/v7", "linux/ppc64le"]'
       noasan_fallback_platforms: "[]"
       skip_empty_merge: true
       tcw_commit_hash: ${{ inputs.tcw_commit_hash }}
@@ -91,9 +94,10 @@ jobs:
     with:
       system: "debianAsanTest"
       dockerfile: "DockerfileDebian"
-      platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      # arm64 is promoted to the main build; these remain ASAN-broken under QEMU.
+      platforms: '["linux/arm/v7", "linux/ppc64le"]'
       primary_image: false
-      error_platforms: '["linux/arm/v7", "linux/arm64/v8", "linux/ppc64le"]'
+      error_platforms: '["linux/arm/v7", "linux/ppc64le"]'
       noasan_fallback_platforms: "[]"
       skip_empty_merge: true
       tcw_commit_hash: ${{ inputs.tcw_commit_hash }}

--- a/.github/workflows/publish_docker_matrix_base.yml
+++ b/.github/workflows/publish_docker_matrix_base.yml
@@ -49,7 +49,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ fromJson(inputs.platforms) }}
-    runs-on: ubuntu-latest
+    # aarch64 is built/tested natively so AddressSanitizer works (QEMU-user
+    # emulation cannot satisfy libasan's fixed 64-bit allocator mapping).
+    # All other platforms stay on the amd64 runner and cross-build via QEMU.
+    runs-on: ${{ matrix.platform == 'linux/arm64/v8' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -141,10 +144,27 @@ jobs:
           platform=$(echo "${{ matrix.platform }}" | tr '/' '_')
           echo "platform=$platform"
           echo "platform=$platform" >> $GITHUB_OUTPUT
+      - name: Lower ASLR entropy for AddressSanitizer (aarch64)
+        if: ${{ matrix.platform == 'linux/arm64/v8' }}
+        run: |
+          # Native arm64 runners use a recent kernel with vm.mmap_rnd_bits=32, which can
+          # collide with libasan's fixed 64-bit allocator base and abort at startup with
+          # "CHECK failed: sanitizer_allocator_primary64.h". 28 still gives strong ASLR.
+          # Load-bearing when the base image's libasan predates LLVM 17 (GCC <=13); a
+          # no-op for GCC 14+, which moved the allocator base to tolerate 32-bit ASLR.
+          # vm.* sysctls are not namespaced, so this host-level change reaches the
+          # container started below. CI-only; does not touch shipped images. Non-fatal.
+          sudo sysctl -w vm.mmap_rnd_bits=28 || echo "warning: could not set vm.mmap_rnd_bits"
       - name: Run docker image test
         id: docker-test
         run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          # QEMU binfmt is only needed to run foreign-arch containers on the amd64
+          # runner. The native arm64 runner runs arm64 containers directly, and the
+          # multiarch/qemu-user-static helper is not arm64-compatible there
+          # (it fails with "Exec format error"), so skip it for arm64.
+          if [ "${{ matrix.platform }}" != "linux/arm64/v8" ]; then
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          fi
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             docker run -e DOCKER_TEST=1 --platform ${{ matrix.platform }} --name teddyCloud-test teddycloud-test:local
           else

--- a/Makefile
+++ b/Makefile
@@ -86,27 +86,19 @@ endif
 endif
 endif
 
-ifeq ($(build_os_id),"ubuntu")
-ifeq ($(build_arch),"aarch64")
-# Workaround AddressSanitizer: CHECK failed: sanitizer_allocator_primary64.h:131 "((kSpaceBeg)) == ((address_range.Init(TotalSpaceSize, PrimaryAllocatorName, kSpaceBeg)))" (0x500000000000, 0xfffffffffffffff4) (tid=8)
-# LLM: Ubuntu's Linux kernel version 6.5.0-25 increased the number of random bits used for ASLR from 28 to 32 on 64-bit systems7.
-# The AddressSanitizer library hasn't been updated to accommodate this change in the ASLR configuration7.
-# This mismatch causes a CHECK failure in the sanitizer_allocator_primary64.h file, specifically at line 131.
-# But this doesn't work!
-CFLAGS_VERSION+=-DSANITIZER_CAN_USE_ALLOCATOR64=0
-endif
-endif
-
-ifeq ($(build_os_id),"debian")
-ifeq ($(build_arch),"aarch64")
-# Workaround AddressSanitizer: CHECK failed: sanitizer_allocator_primary64.h:131 "((kSpaceBeg)) == ((address_range.Init(TotalSpaceSize, PrimaryAllocatorName, kSpaceBeg)))" (0x500000000000, 0xfffffffffffffff4) (tid=8)
-# LLM: Ubuntu's Linux kernel version 6.5.0-25 increased the number of random bits used for ASLR from 28 to 32 on 64-bit systems7.
-# The AddressSanitizer library hasn't been updated to accommodate this change in the ASLR configuration7.
-# This mismatch causes a CHECK failure in the sanitizer_allocator_primary64.h file, specifically at line 131.
-# But this doesn't work!
-CFLAGS_VERSION+=-DSANITIZER_CAN_USE_ALLOCATOR64=0
-endif
-endif
+# NOTE (issue #311): AddressSanitizer on aarch64 aborts at startup with
+#   CHECK failed: sanitizer_allocator_primary64.h:131 "((kSpaceBeg)) == (...)" (0x500000000000, 0xfffffffffffffff4)
+# when libasan cannot mmap its fixed 64-bit allocator region. TWO triggers cause it:
+#   (1) QEMU-user emulation / small-VA kernels, whose constrained address space cannot
+#       hold the mapping -- this is why the CI cross-built-under-qemu failed; and
+#   (2) high-entropy ASLR (vm.mmap_rnd_bits=32 on recent kernels) colliding with the
+#       allocator base -- this also happens on NATIVE arm64 hardware, probabilistically.
+# Passing -DSANITIZER_CAN_USE_ALLOCATOR64=0 in CFLAGS here has NO effect: that define
+# only matters when libasan itself is compiled, not the application.
+# Fixes: build/test aarch64 on NATIVE arm64 runners (kills trigger 1) and lower ASLR to
+# vm.mmap_rnd_bits=28 in CI (kills trigger 2) -- see publish_docker_matrix_base.yml.
+# libasan from LLVM 17+ (GCC 14+) moved its allocator base 0x600000000000 -> 0x500000000000
+# to tolerate 32-bit ASLR, so a current base image needs no extra workaround; GCC <=13 does.
 
 build_version:=vX.X.X
 build_gitTagPrefix:=$(firstword $(subst _, ,$(build_gitTag)))


### PR DESCRIPTION
Closes #311.

## Root cause

The aarch64 images are cross-built and then run (`docker run` test step) under **QEMU-user emulation**. AddressSanitizer aborts at startup there:

```
CHECK failed: sanitizer_allocator_primary64.h:131 "((kSpaceBeg)) == ((address_range.Init(...)))" (0x500000000000, 0xfffffffffffffff4)
```

QEMU's constrained emulated address space can't host libasan's fixed 64-bit allocator region, so the `mmap` returns `-ENOMEM` (`0xfffffffffffffff4 == -12`). That failing test is why ASan was disabled on arm64 via `NO_SANITIZERS=2` (`noasan_fallback_platforms`).

Side note: the `-DSANITIZER_CAN_USE_ALLOCATOR64=0` workaround in the `Makefile` was a no-op — that define only takes effect when libasan **itself** is compiled, not the application (hence the "But this doesn't work!" comment). Those dead blocks are removed.

## Fix

Build and test aarch64 on **native `ubuntu-24.04-arm` runners** (free for public repos, GA Aug 2025) instead of under QEMU. On real hardware ASan initialises normally, so `linux/arm64/v8` is dropped from `noasan_fallback_platforms` and ships with ASan again (ubuntu + debian). No ASLR/security tradeoff and no change to what's shipped beyond re-enabling ASan.

## Changes

- **publish_docker_matrix_base.yml** — route `linux/arm64/v8` to `ubuntu-24.04-arm` (everything else stays on the amd64 runner + QEMU); add a CI-only `sysctl vm.mmap_rnd_bits=28` before the arm64 test as cheap insurance in case a base image ever ships a pre-LLVM-17 libasan (GCC ≤13).
- **publish_docker_matrix_all.yml** — remove `linux/arm64/v8` from `noasan_fallback_platforms` for ubuntu + debian; narrow the `*AsanTest` canaries to the platforms still under QEMU (`armv7`, `ppc64le`).
- **Makefile** — delete the dead `SANITIZER_CAN_USE_ALLOCATOR64=0` blocks and document the actual cause/fix.

`armv7` and `ppc64le` stay on the QEMU fallback (`NO_SANITIZERS=2`); the AsanTest canary jobs keep probing them.

## Notes / validation

- Reproduced locally on native arm64 (Docker, Apple Silicon): a clean ASan binary on the current `ubuntu:latest`/`debian:latest` toolchains starts fine even at `vm.mmap_rnd_bits=32`; under QEMU it aborts with the issue's CHECK — consistent with the diagnosis.
- This PR's own CI runs the arm64 build + `docker run` test on the native runner (the PR build path loads the image locally and skips push/merge), so the green/red result here directly validates that ASan works on arm64.
- Rollback if ever needed is one line: re-add `"linux/arm64/v8"` to `noasan_fallback_platforms`.