### PR TITLE
ci(windows): fix Build windows by locating vcvars64.bat via vswhere (windows-2025-vs2026)

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,8 +22,11 @@ jobs:
 
     - name: Build windows
       id:  build-zip
-      run: cmd /c "C:\"Program Files"\"Microsoft Visual Studio"\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat && make build PLATFORM=windows SHELL_ENV=bash"
       shell: cmd
+      run: |
+        for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+        if not defined VSINSTALL ( echo Could not locate Visual Studio via vswhere & exit /b 1 )
+        call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" && make build PLATFORM=windows SHELL_ENV=bash
     - name: Check windows executable existence
       id: check_release
       uses: andstor/file-existence-action@v3


### PR DESCRIPTION
## Problem

The `build-windows-amd64` job in `build_release.yml` hardcodes the Visual Studio install path:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
```

GitHub is migrating the `windows-latest` runner image to **`windows-2025-vs2026`** (runner notice: *"windows-latest requests are being redirected to windows-2025-vs2026 by June 15, 2026"*). The new image no longer has the `2022\Enterprise\` path, so the **Build windows** step fails instantly with:

```
The system cannot find the path specified.
##[error]Process completed with exit code 1.
```

This is environmental and **breaks every PR plus `develop` itself** — confirmed failing on `develop` (2026-06-13), #461 (2026-06-14), and #462 (2026-06-16), all at the same step.

## Fix

Resolve the active Visual Studio installation dynamically with `vswhere.exe` (always present at the fixed `Installer` location) and call its `vcvars64.bat`. This is version/edition-agnostic and keeps the existing `make`-based build unchanged.

```cmd
for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
if not defined VSINSTALL ( echo Could not locate Visual Studio via vswhere & exit /b 1 )
call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" && make build PLATFORM=windows SHELL_ENV=bash
```

`microsoft/setup-msbuild` was considered but is insufficient here: it only adds MSBuild to `PATH` and does not set up the `cl.exe`/C++ toolchain environment that the `make` build requires.

## Impact

Unblocks the Windows build for all open PRs (#461, #462) and future ones. No code changes — CI workflow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)