### PR TITLE
feat: track listened status for library files

### DIFF
--- a/include/handler_api.h
+++ b/include/handler_api.h
@@ -38,6 +38,7 @@ error_t handleApiSettingsReset(HttpConnection *connection, const char_t *uri, co
 error_t handleApiTrigger(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
 error_t handleApiFileIndex(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
 error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
+error_t handleApiFileSetListened(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
 error_t handleApiFileUpload(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
 error_t handleApiDirectoryCreate(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);
 error_t handleApiFileDelete(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx);

--- a/include/libraryMeta.h
+++ b/include/libraryMeta.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "fs_port.h"
+#include "error.h"
+
+/*
+ * Minimal, standalone "listened" flag for library files (<file>.<ext>.json sidecar).
+ * Deliberately independent of contentJson_t/load_content_json: that format is shaped
+ * around a Tonie tag's content assignment (source, live, cache, cloud_ruid, ...), none
+ * of which applies to a plain library audio file. Reading only ever looks at the
+ * "listened" key; writing preserves any other keys already present in the sidecar
+ * (e.g. files created by the "migrate to library" feature, which carry a full
+ * contentJson_t blob) instead of overwriting them.
+ */
+
+bool_t library_meta_get_listened(const char *content_path);
+error_t library_meta_set_listened(const char *content_path, bool_t listened);

--- a/include/settings.h
+++ b/include/settings.h
@@ -99,6 +99,7 @@ typedef struct
     bool prioCustomContent;
     bool updateOnLowerAudioId;
     bool dumpRuidAuthContentJson;
+    bool autoMarkListenedOnSync;
 } settings_cloud_t;
 
 typedef struct

--- a/src/handler_api.c
+++ b/src/handler_api.c
@@ -25,6 +25,7 @@
 #include "cert.h"
 #include "esp32.h"
 #include "cache.h"
+#include "libraryMeta.h"
 
 error_t parsePostData(HttpConnection *connection, char_t *post_data, size_t buffer_size)
 {
@@ -671,6 +672,27 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
         char *filePathAbsolute = custom_asprintf("%s%c%s", pathAbsolute, PATH_SEPARATOR, entry.name);
         pathSafeCanonicalize(filePathAbsolute);
 
+        /* skip content.json sidecar files (<file>.json next to <file>), they are not browsable content.
+         * Only hide them when the sibling still exists - an orphaned .json (sibling deleted, e.g. by
+         * cache eviction that didn't clean up after itself) is intentionally left visible, so it can be
+         * spotted and cleaned up manually. */
+        if (!isDir)
+        {
+            size_t nameLen = osStrlen(entry.name);
+            if (nameLen > 5 && !osStrcasecmp(&entry.name[nameLen - 5], ".json"))
+            {
+                char *siblingPath = strdup(filePathAbsolute);
+                siblingPath[osStrlen(siblingPath) - 5] = '\0';
+                bool_t isSidecar = fsFileExists(siblingPath);
+                osFreeMem(siblingPath);
+                if (isSidecar)
+                {
+                    osFreeMem(filePathAbsolute);
+                    continue;
+                }
+            }
+        }
+
         cJSON *jsonEntry = cJSON_CreateObject();
         cJSON_AddStringToObject(jsonEntry, "name", entry.name);
         cJSON_AddNumberToObject(jsonEntry, "date", convertDateToUnixTime(&entry.modified));
@@ -708,6 +730,8 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
                 cJSON_AddItemToArray(tracksArray, cJSON_CreateNumber(tafInfo->additional.track_positions.pos[i]));
             }
 
+            cJSON_AddBoolToObject(jsonEntry, "listened", library_meta_get_listened(filePathAbsolute));
+
             item = tonies_byAudioIdHashModel(tafInfo->tafHeader->audio_id, tafInfo->tafHeader->sha1_hash.data, tafInfo->json.tonie_model);
         }
         else
@@ -718,6 +742,7 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
                 char *filePathAbsoluteSub = NULL;
                 FsDir *subdir = fsOpenDir(filePathAbsolute);
                 FsDirEntry subentry;
+                bool_t subHide = false;
                 if (subdir != NULL)
                 {
                     while (true)
@@ -739,9 +764,10 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
                         load_content_json(filePathAbsoluteSub, &contentJson, false, client_ctx->settings);
                         item = tonies_byModel(contentJson.tonie_model);
                         osFreeMem(filePathAbsoluteSub);
-                        cJSON_AddBoolToObject(jsonEntry, "hide", contentJson.hide);
+                        subHide = contentJson.hide;
                         free_content_json(&contentJson);
                     }
+                    cJSON_AddBoolToObject(jsonEntry, "hide", subHide);
                 }
             }
             else
@@ -756,6 +782,7 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
                 item = tonies_byModel(contentJson.tonie_model);
 
                 cJSON_AddBoolToObject(jsonEntry, "hide", contentJson.hide);
+                cJSON_AddBoolToObject(jsonEntry, "listened", library_meta_get_listened(filePathAbsolute));
                 if (contentJson._has_cloud_auth)
                 {
                     cJSON_AddBoolToObject(jsonEntry, "has_cloud_auth", true);
@@ -782,6 +809,65 @@ error_t handleApiFileIndexV2(HttpConnection *connection, const char_t *uri, cons
     connection->response.contentLength = osStrlen(jsonString);
 
     return httpWriteResponse(connection, jsonString, connection->response.contentLength, true);
+}
+error_t handleApiFileSetListened(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx)
+{
+    char overlay[16];
+    const char *rootPath = NULL;
+
+    if (queryPrepare(queryString, &rootPath, overlay, sizeof(overlay), &client_ctx->settings) != NO_ERROR)
+    {
+        return ERROR_FAILURE;
+    }
+
+    char path[128];
+
+    if (!queryGet(queryString, "path", path, sizeof(path)))
+    {
+        TRACE_ERROR("path missing!\r\n");
+        return ERROR_INVALID_REQUEST;
+    }
+
+    /* first canonicalize path, then merge to prevent directory traversal bugs */
+    pathSafeCanonicalize(path);
+    char *pathAbsolute = custom_asprintf("%s%c%s", rootPath, PATH_SEPARATOR, path);
+    pathSafeCanonicalize(pathAbsolute);
+
+    if (!fsFileExists(pathAbsolute))
+    {
+        TRACE_ERROR("File not found: '%s'\r\n", pathAbsolute);
+        osFreeMem(pathAbsolute);
+        return ERROR_NOT_FOUND;
+    }
+
+    char_t post_data[POST_BUFFER_SIZE];
+    error_t error = parsePostData(connection, post_data, POST_BUFFER_SIZE);
+    if (error != NO_ERROR)
+    {
+        osFreeMem(pathAbsolute);
+        return error;
+    }
+
+    char item_data[16];
+    bool_t target_value = false;
+    if (queryGet(post_data, "listened", item_data, sizeof(item_data)))
+    {
+        target_value = !osStrcmp(item_data, "true");
+    }
+
+    if (library_meta_get_listened(pathAbsolute) != target_value)
+    {
+        error = library_meta_set_listened(pathAbsolute, target_value);
+    }
+
+    osFreeMem(pathAbsolute);
+
+    if (error != NO_ERROR)
+    {
+        return error;
+    }
+
+    return httpOkResponse(connection);
 }
 error_t handleApiFileIndex(HttpConnection *connection, const char_t *uri, const char_t *queryString, client_ctx_t *client_ctx)
 {

--- a/src/handler_cloud.c
+++ b/src/handler_cloud.c
@@ -17,6 +17,7 @@
 #include "toniefile.h"
 #include "toniesJson.h"
 #include "tonie_audio_playlist.h"
+#include "libraryMeta.h"
 #include "cJSON.h"
 
 #include <byteswap.h>
@@ -738,6 +739,17 @@ error_t handleCloudContentExt(HttpConnection *connection, const char_t *uri, con
     {
         TRACE_INFO("Serve local content from %s\r\n", tonieInfo->contentPath);
         connection->response.keepAlive = true;
+
+        if (client_ctx->settings->cloud.autoMarkListenedOnSync && tonieInfo->json._source_type == CT_SOURCE_TAF)
+        {
+            /* Download-time heuristic: a future iteration could use the RTNL-derived
+             * "Playback ON/OFF" MQTT events (toniebox_state.c) for a real playback-based signal.
+             * This mutates the library file's own listened flag, not tonieInfo->json (the tag's). */
+            if (!library_meta_get_listened(tonieInfo->contentPath))
+            {
+                library_meta_set_listened(tonieInfo->contentPath, true);
+            }
+        }
 
         if (tonieInfo->json._source_type == CT_SOURCE_TAF_INCOMPLETE)
         {

--- a/src/libraryMeta.c
+++ b/src/libraryMeta.c
@@ -1,0 +1,93 @@
+#include "libraryMeta.h"
+
+#include "cJSON.h"
+#include "os_port.h"
+#include "debug.h"
+#include "json_helper.h"
+#include "server_helpers.h"
+#include "fs_ext.h"
+
+static cJSON *library_meta_read(const char *json_path)
+{
+    if (!fsFileExists(json_path))
+    {
+        return cJSON_CreateObject();
+    }
+
+    size_t fileSize = 0;
+    fsGetFileSize(json_path, (uint32_t *)(&fileSize));
+
+    FsFile *fsFile = fsOpenFile(json_path, FS_FILE_MODE_READ);
+    if (fsFile == NULL)
+    {
+        return cJSON_CreateObject();
+    }
+
+    size_t sizeRead;
+    char *data = osAllocMem(fileSize);
+    size_t pos = 0;
+
+    while (pos < fileSize)
+    {
+        fsReadFile(fsFile, &data[pos], fileSize - pos, &sizeRead);
+        pos += sizeRead;
+    }
+    fsCloseFile(fsFile);
+
+    cJSON *root = cJSON_ParseWithLengthOpts(data, fileSize, 0, 0);
+    osFreeMem(data);
+
+    if (root == NULL)
+    {
+        TRACE_WARNING("Failed to parse library meta json '%s', starting fresh\r\n", json_path);
+        return cJSON_CreateObject();
+    }
+
+    return root;
+}
+
+bool_t library_meta_get_listened(const char *content_path)
+{
+    char *jsonPath = custom_asprintf("%s.json", content_path);
+    cJSON *root = library_meta_read(jsonPath);
+    bool_t listened = jsonGetBool(root, "listened");
+    cJSON_Delete(root);
+    osFreeMem(jsonPath);
+    return listened;
+}
+
+error_t library_meta_set_listened(const char *content_path, bool_t listened)
+{
+    char *jsonPath = custom_asprintf("%s.json", content_path);
+    cJSON *root = library_meta_read(jsonPath);
+
+    cJSON_DeleteItemFromObject(root, "listened");
+    cJSON_AddBoolToObject(root, "listened", listened);
+
+    char *jsonPathTmp = custom_asprintf("%s.tmp", jsonPath);
+    error_t error = NO_ERROR;
+    char *jsonRaw = cJSON_Print(root);
+
+    FsFile *file = fsOpenFile(jsonPathTmp, FS_FILE_MODE_WRITE);
+    if (file != NULL)
+    {
+        error = fsWriteFile(file, jsonRaw, osStrlen(jsonRaw));
+        fsCloseFile(file);
+    }
+    else
+    {
+        error = ERROR_FILE_OPENING_FAILED;
+    }
+
+    if (error == NO_ERROR)
+    {
+        error = fsMoveFile(jsonPathTmp, jsonPath, true);
+    }
+
+    cJSON_Delete(root);
+    osFreeMem(jsonRaw);
+    osFreeMem(jsonPathTmp);
+    osFreeMem(jsonPath);
+
+    return error;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -137,6 +137,7 @@ request_type_t request_paths[] = {
     {REQ_POST, "/api/pcmUpload", SERTY_WEB, &handleApiPcmUpload},
     {REQ_POST, "/api/tafUpload", SERTY_WEB, &handleApiTafUpload},
     {REQ_GET, "/api/fileIndexV2", SERTY_WEB, &handleApiFileIndexV2},
+    {REQ_POST, "/api/fileSetListened", SERTY_WEB, &handleApiFileSetListened},
     {REQ_GET, "/api/fileIndex", SERTY_WEB, &handleApiFileIndex},
     {REQ_GET, "/api/stats", SERTY_WEB, &handleApiStats},
     {REQ_GET, "/api/toniesJsonSearch", SERTY_WEB, &handleApiToniesJsonSearch},

--- a/src/settings.c
+++ b/src/settings.c
@@ -281,6 +281,7 @@ static void option_map_init(uint8_t settingsId)
     OPTION_BOOL("cloud.prioCustomContent", &settings->cloud.prioCustomContent, TRUE, "Prioritize custom content", "Prioritize custom content over tonies content (force update, only if \"Update content on lower audio id\" is disabled)", LEVEL_EXPERT)
     OPTION_BOOL("cloud.updateOnLowerAudioId", &settings->cloud.updateOnLowerAudioId, TRUE, "Update content on lower audio id", "Update content on a lower audio id", LEVEL_EXPERT)
     OPTION_BOOL("cloud.dumpRuidAuthContentJson", &settings->cloud.dumpRuidAuthContentJson, TRUE, "Dump rUID/auth", "Dump the rUID and authentication into the content JSON.", LEVEL_EXPERT)
+    OPTION_BOOL("cloud.autoMarkListenedOnSync", &settings->cloud.autoMarkListenedOnSync, TRUE, "Auto-mark listened on sync", "Automatically mark library content as listened once a Toniebox downloads/plays it from this server", LEVEL_BASIC)
 
     OPTION_TREE_DESC("encode", "TAF encoding", LEVEL_EXPERT)
     OPTION_UNSIGNED("encode.bitrate", &settings->encode.bitrate, 96, 0, 256, "Opus bitrate", "Opus bitrate, tested 64, 96(default), 128, 192, 256 - be aware that this increases the TAF size!", LEVEL_EXPERT)


### PR DESCRIPTION
## Summary
- Adds a minimal, standalone "listened" flag for library files, stored in a
  lightweight sidecar independent of `contentJson_t` (which is shaped around
  a Tonie tag's content assignment — source, live, cache, cloud auth — none
  of which applies to a plain library file)
- New `listened` field on `GET /api/fileIndexV2` for library entries
- New `POST /api/fileSetListened` to toggle it for an arbitrary file
- New `cloud.autoMarkListenedOnSync` setting (on by default): marks a
  library-sourced tag's file as listened once a Toniebox actually
  downloads/plays it locally
- Fixes a pre-existing duplicate-key bug in `fileIndexV2`'s directory
  listing branch (the "hide" field was being added once per scanned
  subentry instead of once per directory)
- Orphaned sidecars (whose original file was deleted, e.g. by cache
  eviction) are intentionally left visible in listings rather than hidden,
  so they can be spotted and cleaned up manually

## Why not just extend contentJson_t?
`contentJson_t` describes how a Tonie *tag* is configured (`source`, `live`,
`cache`, `cloud_ruid`, `tonie_model`, ...). None of that applies to a plain
library file. Reusing it would give every newly-marked file a sidecar full
of irrelevant empty fields. The new format only ever touches the `listened`
key and preserves any other keys already present in the sidecar (e.g. ones
left behind by the "migrate to library" feature).

## cloud.autoMarkListenedOnSync
- Fires on download/sync to a box, not on actual playback completion
- Alternatives considered:
  - manual-only (no auto-marking) — most accurate, but tedious
  - real playback signal via existing RTNL `Playback ON/OFF` MQTT events — better, deferred as follow-up (noted in code comment)
  - download-time heuristic (chosen) — cheap, correlates well enough, one settings toggle to disable
- Default on, can be turned off if it produces false positives (e.g. re-sync of already-cached content)

## Companion PR
Pairs with the frontend changes: toniebox-reverse-engineering/teddycloud_web#317
That PR adds the "listened" toggle to the Library file browser and the
"assign next episode" action on Tonie cards. Without this backend PR those
API calls will 404.

## Test plan
- [ ] `GET /api/fileIndexV2?path=...&special=library` returns `listened` for TAF entries
- [ ] `POST /api/fileSetListened` with `listened=true` persists, reflected on next `fileIndexV2` call
- [ ] Sidecar for a never-touched file contains only `{"listened": true}`
- [ ] Toggling `listened` on a file with an existing full-format sidecar (e.g. from "migrate to library") preserves all other fields
- [ ] With `cloud.autoMarkListenedOnSync` enabled, a library-sourced tag is marked listened after being served to a box
- [ ] Orphaned `.json` sidecars (no matching file) still show up in the Library listing
