### PR TITLE
fix(tls): make the TB2 (ECDSA) server certificate opt-in

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -328,6 +328,7 @@ typedef struct
     char *sslkeylogfile;
     settings_cert_opt_t server_cert;
     settings_cert_opt_t server_cert_tb2;
+    bool server_cert_tb2_enabled;
     settings_cert_opt_t client_cert;
     settings_cert_opt_t client_cert_fake;
     char *allowOrigin;

--- a/src/server.c
+++ b/src/server.c
@@ -730,16 +730,26 @@ error_t httpServerTlsInitCallbackBase(HttpConnection *connection, TlsContext *tl
         return error;
     }
 
-    // Import TB2 server's certificate if available
-    const char *cert_chain_tb2 = settings_get_string("internal.server_tb2.cert_chain");
-    const char *server_key_tb2 = settings_get_string("internal.server_tb2.key");
-
-    if (cert_chain_tb2 && server_key_tb2 && strlen(cert_chain_tb2) > 0 && strlen(server_key_tb2) > 0)
+    // Import the TB2 server certificate only when explicitly enabled.
+    //
+    // The TB2 certificate is an ECDSA certificate. Offering it unconditionally
+    // makes ECDHE_ECDSA cipher suites selectable for every client, including
+    // TB1 boxes. A TB1 box does not trust the TB2 CA and aborts the handshake
+    // ("TLS handshake failure!"), so it never reaches the HTTP layer.
+    // Keep it opt-in until certificate selection can be done per client
+    // (e.g. via SNI / the TB2 hostname).
+    if (settings_get_bool("core.server_cert_tb2.enabled"))
     {
-        error = tlsLoadCertificate(tlsContext, 1, cert_chain_tb2, strlen(cert_chain_tb2), server_key_tb2, strlen(server_key_tb2), NULL);
-        if (error)
+        const char *cert_chain_tb2 = settings_get_string("internal.server_tb2.cert_chain");
+        const char *server_key_tb2 = settings_get_string("internal.server_tb2.key");
+
+        if (cert_chain_tb2 && server_key_tb2 && strlen(cert_chain_tb2) > 0 && strlen(server_key_tb2) > 0)
         {
-            TRACE_WARNING("  Failed to add TB2 cert: %s\r\n", error2text(error));
+            error = tlsLoadCertificate(tlsContext, 1, cert_chain_tb2, strlen(cert_chain_tb2), server_key_tb2, strlen(server_key_tb2), NULL);
+            if (error)
+            {
+                TRACE_WARNING("  Failed to add TB2 cert: %s\r\n", error2text(error));
+            }
         }
     }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -101,6 +101,7 @@ static void option_map_init(uint8_t settingsId)
     OPTION_INTERNAL_STRING("core.server_cert.data.key", &settings->core.server_cert.data.key, "", "Server key data", LEVEL_EXPERT)
 
     OPTION_TREE_DESC("core.server_cert_tb2", "HTTPS server certificates (TB2)", LEVEL_EXPERT)
+    OPTION_BOOL("core.server_cert_tb2.enabled", &settings->core.server_cert_tb2_enabled, FALSE, "Enable TB2 certificate", "Additionally offer the TB2 (ECDSA) server certificate during the TLS handshake. Only enable when a TB2 box is used - TB1 boxes fail the handshake when an ECDSA certificate is offered.", LEVEL_EXPERT)
     OPTION_TREE_DESC("core.server_cert_tb2.file", "File certificates (TB2)", LEVEL_EXPERT)
     OPTION_STRING("core.server_cert_tb2.file.ca", &settings->core.server_cert_tb2.file.ca, "certs/server_tb2/ca-root.pem", "CA certificate (TB2)", "CA certificate (TB2)", LEVEL_EXPERT)
     OPTION_STRING("core.server_cert_tb2.file.ca_der", &settings->core.server_cert_tb2.file.ca_der, "certs/server_tb2/ca.der", "CA certificate as DER (TB2)", "CA certificate as DER (TB2)", LEVEL_EXPERT)


### PR DESCRIPTION
## Problem

Since the TB2 certificate support was added, `httpServerTlsInitCallbackBase()` unconditionally
loads a second server certificate into the TLS context:

```c
// Import TB2 server's certificate if available
const char *cert_chain_tb2 = settings_get_string("internal.server_tb2.cert_chain");
const char *server_key_tb2 = settings_get_string("internal.server_tb2.key");

if (cert_chain_tb2 && server_key_tb2 && ...)
{
    error = tlsLoadCertificate(tlsContext, 1, ...);
}
```

On `develop` this breaks **all TB1 boxes**. The log only shows:

```
WARN |tls_server_fsm.c:0260:tlsPerformServerHandshake| TLS handshake failure!
WARN |tls_server_fsm.c:0260:tlsPerformServerHandshake| TLS handshake failure!
```

and nothing else — no request ever reaches the HTTP layer, so every downstream feature looks
broken (content requests, live/stream tonies, freshness checks). On `master` the same setup works.

### Root cause

The TB2 certificate is an **ECDSA** certificate (`cert_generate_signed_ec("tbs2.tonie.cloud", ...)`,
signed by the TB2 CA). CycloneSSL selects the cipher suite first and then looks for a matching
certificate (`tlsSelectCertificate()` in `tls_server_misc.c`, looping over all
`TLS_MAX_CERTIFICATES` slots). As soon as an ECDSA certificate is present, `ECDHE_ECDSA` cipher
suites become selectable for *every* client — including TB1 boxes, which do offer those suites in
their ClientHello but only trust the (RSA) Boxine/TeddyCloud CA. The server then answers a TB1
box with the TB2 ECDSA certificate and the box aborts the handshake.

Because the failure happens inside the handshake, there is no way to distinguish the box
generation beforehand: the User-Agent based detection in `httpServerRequestCallback()` runs far
too late, and CycloneSSL currently exposes no SNI/certificate-selection callback.

## Change

Make the second certificate opt-in via a new expert setting, defaulting to the pre-regression
behaviour:

* `include/settings.h`: new `bool server_cert_tb2_enabled` in the core settings.
* `src/settings.c`: new option `core.server_cert_tb2.enabled` (default `FALSE`, `LEVEL_EXPERT`).
* `src/server.c`: only load the TB2 certificate when that option is enabled.

No behaviour change for TB2 users beyond flipping one setting, and TB1 setups are restored to the
`master` behaviour out of the box.

## Follow-up (not part of this PR)

The proper fix is per-connection certificate selection. Two options:

1. Select by SNI: the TB2 certificate is issued for `tbs2.tonie.cloud`, TB1 boxes use the
   `*.tonie.cloud` RSA chain. This needs a small addition to the vendored CycloneSSL
   (a server-name/certificate-selection hook) since `tls.h` has no `tlsSetSniCallback()`.
2. Terminate TB2 traffic on a dedicated listener/port and load the ECDSA certificate only there.

Once either is in place, the setting introduced here can default to `TRUE` or be dropped.

## Testing

* Clean build of `develop` with the patch: `make -j8 NO_SANITIZERS=2` — no new warnings.
* TB1 box (CC3200/ESP32): handshake succeeds again, requests appear in the log, live/stream
  tonies start ffmpeg as expected.
* With `core.server_cert_tb2.enabled=true` the previous (regressed) behaviour is reproduced
  exactly, confirming the diagnosis.