### PR TITLE
fix(toniefile): keep TAF block alignment when opus emits very small packets

### DIFF
--- a/include/toniefile.h
+++ b/include/toniefile.h
@@ -16,6 +16,9 @@
 #define TONIEFILE_PAD_END 64
 
 #define OGG_HEADER_LENGTH 27
+/* max lacing values per ogg page (255), minus a safety margin for the packet
+   that finally fills the block */
+#define OGG_SEGMENTS_RESERVE 8
 /*
     quint32 Signature;
     quint8 Version;

--- a/src/toniefile.c
+++ b/src/toniefile.c
@@ -449,6 +449,35 @@ error_t toniefile_encode(toniefile_t *ctx, int16_t *sample_buffer, size_t sample
                 return ERROR_FAILURE;
             }
 
+            /* An ogg page can hold at most 255 lacing values (segments) and every
+               packet consumes at least one of them. Very small packets - which
+               opus produces for silence or very quiet passages - would therefore
+               run out of segments long before the 4096 byte block is filled.
+               libogg then splits the page, the extra page header shifts the write
+               position and the block alignment check below fails, aborting the
+               whole (web radio) stream. Make sure every packet is big enough that
+               the remaining space can still be filled with the remaining segments. */
+            int segments_left = 255 - (int)ctx->os.lacing_fill - OGG_SEGMENTS_RESERVE;
+            if (segments_left < 1)
+            {
+                segments_left = 1;
+            }
+            int min_payload = (page_remain + segments_left - 1) / segments_left;
+            if (min_payload > frame_payload)
+            {
+                min_payload = frame_payload;
+            }
+            if (frame_len < min_payload)
+            {
+                int ret = opus_packet_pad(output_frame, frame_len, min_payload);
+                if (ret < 0)
+                {
+                    TRACE_ERROR("Cannot pad: %s\r\n", opus_strerror(ret));
+                    return ERROR_FAILURE;
+                }
+                frame_len = min_payload;
+            }
+
             /* we did not exactly hit the destination size and are close to block size. pad packet */
             if (frame_payload - frame_len < OPUS_PACKET_PAD)
             {


### PR DESCRIPTION
## Symptom

Encoding aborts – reproducibly on web radio streams with quiet/silent passages,
but also on normal file encodes containing silence:

```
ERROR|toniefile.c:0529:toniefile_encode| Block alignment mismatch 0x0000101B
ERROR|toniefile.c:0985:ffmpeg_stream| Could not encode toniesample error=Generic error code [1]
[aost#0:0/pcm_s16le] Error submitting a packet to the muxer: Broken pipe
```

ffmpeg is *not* the cause – it only dies with `Broken pipe` because teddyCloud
closed the pipe after the encode error. For live streams this ends playback on
the box ("web radio keeps dropping").

## Root cause

An ogg page can carry at most **255 lacing values (segments)**, and *every*
packet consumes at least one segment.

`toniefile_encode()` sizes each opus packet so that the current 4096-byte TAF
block is filled exactly, and pads a packet only when it already comes close to
that size (`frame_payload - frame_len < OPUS_PACKET_PAD`).

For silence or very quiet audio, `opus_encode()` returns packets of only a few
bytes. Those are far from `frame_payload`, so they are never padded and simply
accumulate in the page. Filling 4096 bytes with 3-byte packets would require
well over a thousand segments – but at 255 libogg splits the page. The extra
page header (27 bytes) is not part of the space calculation, the write position
drifts off the 4096 grid, and the alignment check fires:

```
INFO  FLUSHDBG hdr=282 body=2040 prev=512  pos=2834   <- 255 segments, page split
INFO  FLUSHDBG hdr=161 body=1128 prev=2834 pos=4123   <- 0x101B, misaligned
ERROR Block alignment mismatch 0x0000101B
```

`hdr=282` is `27 + 255` – the page ran into the segment limit.

## Fix

Before the existing "close to block size" padding, pad every packet to the
minimum size that still allows the rest of the block to be filled with the
remaining segment budget:

```c
int segments_left = 255 - (int)ctx->os.lacing_fill - OGG_SEGMENTS_RESERVE;
int min_payload   = (page_remain + segments_left - 1) / segments_left;
if (frame_len < min_payload)
    opus_packet_pad(output_frame, frame_len, min_payload);
```

`OGG_SEGMENTS_RESERVE` (8) keeps headroom for the packet that finally closes
the block. Normal content is unaffected – its packets are already larger than
`min_payload`, so no additional padding is applied and the bitstream is
byte-identical to before.

## Test

* 60 s digital silence: fails on `develop` with `Block alignment mismatch
  0x0000101B`, encodes successfully with the patch (20480 bytes = 5 blocks, so
  no meaningful size penalty).
* 30 s sine tone: encodes fine, resulting ogg payload probes as
  `format_name=ogg, duration=29.82`.
* 100 s live web radio (`ice1.somafm.com/groovesalad-128-mp3`): no errors,
  file size a multiple of 4096, SHA1/length self-check passes.